### PR TITLE
Fix Cosmos transaction builder

### DIFF
--- a/api/account/account.go
+++ b/api/account/account.go
@@ -56,7 +56,7 @@ type Tx interface {
 // information, and this should be accepted during the construction of the
 // chain-specific transaction builder.
 type TxBuilder interface {
-	BuildTx(from, to address.Address, value, nonce, gasLimit, gasPrice pack.U256, payload pack.Bytes) (Tx, error)
+	BuildTx(ctx context.Context, from, to address.Address, value, nonce, gasLimit, gasPrice pack.U256, payload pack.Bytes) (Tx, error)
 }
 
 // The AccountInfo interface defines functionality that must expose account

--- a/chain/cosmos/client.go
+++ b/chain/cosmos/client.go
@@ -179,3 +179,19 @@ func (client *Client) AccountInfo(_ context.Context, addr address.Address) (acco
 		coins:          parseCoins(acc.GetCoins()),
 	}, nil
 }
+
+// AccountNumber returns the account number for a given address.
+func (client *Client) AccountNumber(_ context.Context, addr address.Address) (pack.U64, error) {
+	cosmosAddr, err := types.AccAddressFromBech32(string(addr))
+	if err != nil {
+		return 0, fmt.Errorf("bad address: '%v': %v", addr, err)
+	}
+
+	accGetter := auth.NewAccountRetriever(client.cliCtx)
+	acc, err := accGetter.GetAccount(Address(cosmosAddr).AccAddress())
+	if err != nil {
+		return 0, err
+	}
+
+	return pack.U64(acc.GetAccountNumber()), nil
+}

--- a/chain/cosmos/client.go
+++ b/chain/cosmos/client.go
@@ -101,21 +101,6 @@ func (client *Client) Tx(ctx context.Context, txHash pack.Bytes) (account.Tx, pa
 		return &StdTx{}, pack.NewU64(0), fmt.Errorf("parse tx failed: %v", err)
 	}
 
-	// Construct a past context (just before the transaction's height) and query
-	// the sender account to know the nonce (sequence number) with which this
-	// transaction was broadcasted.
-	senderAddr, err := types.AccAddressFromBech32(string(stdTx.From()))
-	if err != nil {
-		return &StdTx{}, pack.NewU64(0), fmt.Errorf("bad address '%v': %v", stdTx.From(), err)
-	}
-	pastContext := client.cliCtx.WithHeight(res.Height - 1)
-	accGetter := auth.NewAccountRetriever(pastContext)
-	acc, err := accGetter.GetAccount(senderAddr)
-	if err != nil {
-		return &StdTx{}, pack.NewU64(0), fmt.Errorf("account query failed: %v", err)
-	}
-	stdTx.signMsg.Sequence = acc.GetSequence()
-
 	return &stdTx, pack.NewU64(1), nil
 }
 

--- a/chain/filecoin/account.go
+++ b/chain/filecoin/account.go
@@ -2,6 +2,7 @@ package filecoin
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	filaddress "github.com/filecoin-project/go-address"
@@ -28,7 +29,7 @@ func NewTxBuilder(gasPremium pack.U256) TxBuilder {
 }
 
 // BuildTx receives transaction fields and constructs a new transaction.
-func (txBuilder TxBuilder) BuildTx(from, to address.Address, value, nonce, gasLimit, gasFeeCap pack.U256, payload pack.Bytes) (account.Tx, error) {
+func (txBuilder TxBuilder) BuildTx(ctx context.Context, from, to address.Address, value, nonce, gasLimit, gasFeeCap pack.U256, payload pack.Bytes) (account.Tx, error) {
 	filfrom, err := filaddress.NewFromString(string(from))
 	if err != nil {
 		return nil, fmt.Errorf("bad from address '%v': %v", from, err)

--- a/chain/filecoin/filecoin_test.go
+++ b/chain/filecoin/filecoin_test.go
@@ -72,6 +72,7 @@ var _ = Describe("Filecoin", func() {
 
 			// build the transaction
 			tx, err := filTxBuilder.BuildTx(
+				ctx,
 				multichain.Address(pack.String(senderFilAddr.String())),
 				multichain.Address(pack.String(recipientFilAddr.String())),
 				pack.NewU256FromU64(pack.NewU64(100000000)), // amount

--- a/chain/terra/terra.go
+++ b/chain/terra/terra.go
@@ -30,6 +30,6 @@ func NewClient(opts ClientOptions) *Client {
 // NewTxBuilder returns an implementation of the transaction builder interface
 // from the Cosmos Compat API, and exposes the functionality to build simple
 // Terra transactions.
-func NewTxBuilder(opts TxBuilderOptions) account.TxBuilder {
-	return cosmos.NewTxBuilder(opts)
+func NewTxBuilder(opts TxBuilderOptions, client *Client) account.TxBuilder {
+	return cosmos.NewTxBuilder(opts, client)
 }

--- a/chain/terra/terra_test.go
+++ b/chain/terra/terra_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/renproject/pack"
 	"github.com/renproject/surge"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
-	"github.com/terra-project/core/app"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -61,16 +60,15 @@ var _ = Describe("Terra", func() {
 
 				// create a new cosmos-compatible transaction builder
 				txBuilder := terra.NewTxBuilder(terra.TxBuilderOptions{
-					AccountNumber: pack.NewU64(1),
-					ChainID:       "testnet",
-					CoinDenom:     "uluna",
-					Cdc:           app.MakeCodec(),
-				})
+					ChainID:   "testnet",
+					CoinDenom: "uluna",
+				}, client)
 
 				// build the transaction
 				payload := pack.NewBytes([]byte("multichain"))
 				amount := pack.NewU256FromU64(pack.U64(2000000))
 				tx, err := txBuilder.BuildTx(
+					ctx,
 					multichain.Address(addr.String()),     // from
 					recipient,                             // to
 					amount,                                // amount

--- a/infra/.env
+++ b/infra/.env
@@ -1,9 +1,4 @@
 #
-# RenVM's deterministic private key for test purposes
-#
-export RENVM_PK=8d00ff6a38267c5ecda940dc8a64948bde5a2fdc2a609041f2fdb1605f8794f6
-
-#
 # Binance Smart Chain
 #
 
@@ -72,7 +67,6 @@ export FILECOIN_ADDRESS=t1ej2tountzqwnu6uswhqdzvw6yy5xvcig6rxl2qa
 # suite access to plenty of testing funds.
 export TERRA_PK=a96e62ed3955e65be32703f12d87b6b5cf26039ecfa948dc5107a495418e5330
 export TERRA_ADDRESS=terra10s4mg25tu6termrk8egltfyme4q7sg3hl8s38u
-export RENVM_TERRA_ADDRESS=terra1mclmytf3657uzw0cj3hcmu98vpj4t9ekdks6tc
 
 #
 # Zcash

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -147,4 +147,3 @@ services:
     entrypoint:
       - "./root/run.sh"
       - "${TERRA_ADDRESS}"
-      - "${RENVM_TERRA_ADDRESS}"

--- a/infra/terra/run.sh
+++ b/infra/terra/run.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 ADDRESS=$1
-ADDRESS_2=$2
 
 # Print setup
 echo "TERRA_ADDRESS=$ADDRESS"
-echo "RENVM_TERRA_ADDRESS=$ADDRESS_2"
 
 # Register client key
 terracli keys add validator --keyring-backend=test
@@ -14,7 +12,6 @@ echo $(terracli keys show validator)
 terrad init testnet --chain-id testnet
 terrad add-genesis-account $(terracli keys show validator -a --keyring-backend=test) 10000000000uluna
 terrad add-genesis-account $ADDRESS 10000000000uluna,10000000000ukrw,10000000000uusd,10000000000usdr,10000000000umnt
-terrad add-genesis-account $ADDRESS_2 10000000000uluna,10000000000ukrw,10000000000uusd,10000000000usdr,10000000000umnt
 terrad gentx --amount 10000000000uluna --name validator --keyring-backend=test
 terrad collect-gentxs
 

--- a/multichain_test.go
+++ b/multichain_test.go
@@ -23,7 +23,6 @@ import (
 	filtypes "github.com/filecoin-project/lotus/chain/types"
 	"github.com/renproject/id"
 	"github.com/renproject/multichain"
-	"github.com/renproject/multichain/api/account"
 	"github.com/renproject/multichain/chain/bitcoin"
 	"github.com/renproject/multichain/chain/bitcoincash"
 
@@ -353,7 +352,7 @@ var _ = Describe("Multichain", func() {
 
 					return client
 				},
-				func(client multichain.AccountClient) account.TxBuilder {
+				func(client multichain.AccountClient) multichain.AccountTxBuilder {
 					return terra.NewTxBuilder(terra.TxBuilderOptions{
 						ChainID:   "testnet",
 						CoinDenom: "uluna",


### PR DESCRIPTION
Previously, the transaction builder would require the user to specify the account number upon instantiating the object. This is obviously an issue if the transaction builder is expected to work for multiple different accounts, as each of them would have a different account number. The transaction builder interface has now been updated to accept a `Client` which can be used to fetch the account number upon building the transaction, rather than upon initialisation of the builder. Additionally, some slightly incorrect logic regarding nonce (sequence number) fetching has been removed.