### PR TITLE
bitcoin fee estimation

### DIFF
--- a/chain/bitcoin/gas.go
+++ b/chain/bitcoin/gas.go
@@ -6,27 +6,44 @@ import (
 	"github.com/renproject/pack"
 )
 
+const (
+	btcToSatoshis  = 1e8
+	kilobyteToByte = 1024
+)
+
 // A GasEstimator returns the SATs-per-byte that is needed in order to confirm
 // transactions with an estimated maximum delay of one block. In distributed
 // networks that collectively build, sign, and submit transactions, it is
 // important that all nodes in the network have reached consensus on the
 // SATs-per-byte.
 type GasEstimator struct {
-	satsPerByte pack.U256
+	client    Client
+	numBlocks int64
 }
 
 // NewGasEstimator returns a simple gas estimator that always returns the given
 // number of SATs-per-byte.
-func NewGasEstimator(satsPerByte pack.U256) GasEstimator {
+func NewGasEstimator(client Client, numBlocks int64) GasEstimator {
 	return GasEstimator{
-		satsPerByte: satsPerByte,
+		client:    client,
+		numBlocks: numBlocks,
 	}
 }
 
 // EstimateGasPrice returns the number of SATs-per-byte that is needed in order
-// to confirm transactions with an estimated maximum delay of one block. It is
-// the responsibility of the caller to know the number of bytes in their
-// transaction.
-func (gasEstimator GasEstimator) EstimateGasPrice(_ context.Context) (pack.U256, pack.U256, error) {
-	return gasEstimator.satsPerByte, pack.NewU256([32]byte{}), nil
+// to confirm transactions with an estimated maximum delay of `numBlocks` block.
+// It is the responsibility of the caller to know the number of bytes in their
+// transaction. This method calls the `estimatesmartfee` RPC call to the node,
+// which based on a conservative (considering longer history) strategy returns
+// the estimated BTC per kilobyte of data in the transaction. An error will be
+// returned if the bitcoin node hasn't observed enough blocks to make an
+// estimate for the provided target `numBlocks`.
+func (gasEstimator GasEstimator) EstimateGasPrice(ctx context.Context) (pack.U256, pack.U256, error) {
+	feeRate, err := gasEstimator.client.EstimateSmartFee(ctx, gasEstimator.numBlocks)
+	if err != nil {
+		return pack.NewU256([32]byte{}), pack.NewU256([32]byte{}), err
+	}
+
+	satsPerByte := uint64(feeRate * btcToSatoshis / kilobyteToByte)
+	return pack.NewU256FromU64(pack.NewU64(satsPerByte)), pack.NewU256([32]byte{}), nil
 }

--- a/chain/bitcoin/gas_test.go
+++ b/chain/bitcoin/gas_test.go
@@ -1,1 +1,40 @@
 package bitcoin_test
+
+import (
+	"context"
+
+	"github.com/renproject/multichain/chain/bitcoin"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Gas", func() {
+	Context("when estimating bitcoin network fee", func() {
+		It("should work", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			client := bitcoin.NewClient(bitcoin.DefaultClientOptions())
+
+			// estimate fee to include tx within 1 block.
+			gasEstimator1 := bitcoin.NewGasEstimator(client, 1)
+			gasPrice1, _, err := gasEstimator1.EstimateGasPrice(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			// estimate fee to include tx within 10 blocks.
+			gasEstimator2 := bitcoin.NewGasEstimator(client, 10)
+			gasPrice2, _, err := gasEstimator2.EstimateGasPrice(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			// estimate fee to include tx within 100 blocks.
+			gasEstimator3 := bitcoin.NewGasEstimator(client, 100)
+			gasPrice3, _, err := gasEstimator3.EstimateGasPrice(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			// expect fees in this order at the very least.
+			Expect(gasPrice1.GreaterThanEqual(gasPrice2)).To(BeTrue())
+			Expect(gasPrice2.GreaterThanEqual(gasPrice3)).To(BeTrue())
+		})
+	})
+})

--- a/infra/bitcoin/run.sh
+++ b/infra/bitcoin/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 ADDRESS=$1
+PRIV_KEY=$2
 
 # Start
 /app/bin/bitcoind
@@ -11,12 +12,19 @@ echo "BITCOIN_ADDRESS=$ADDRESS"
 # Import the address
 /app/bin/bitcoin-cli importaddress $ADDRESS
 
+# Import the private key to spend UTXOs
+/app/bin/bitcoin-cli importprivkey $PRIV_KEY
+
 # Generate enough block to pass the maturation time
 /app/bin/bitcoin-cli generatetoaddress 101 $ADDRESS
 
 # Simulate mining
 while :
 do
+    # generate new btc to the address
     /app/bin/bitcoin-cli generatetoaddress 1 $ADDRESS
-    sleep 10
+    sleep 5
+    # send tx to own address while paying fee to the miner
+    /app/bin/bitcoin-cli sendtoaddress $ADDRESS 0.5 "" "" true
+    sleep 5
 done

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -37,6 +37,7 @@ services:
     entrypoint:
       - "./root/run.sh"
       - "${BITCOIN_ADDRESS}"
+      - "${BITCOIN_PK}"
 
   #
   # Bitcoin Cash


### PR DESCRIPTION
Estimate network fee to be paid (sats per byte) needed to confirm the transaction within the desired number of blocks.
* RPC call used: `estimatesmartfee`
* Error on HTTP error
* Error on not enough chain history to make an estimate