### PR TITLE
Multichain base image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,3 +87,28 @@ jobs:
             source ./infra/.env
             cd $GITHUB_WORKSPACE
             CI=true go test -timeout 1500s
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: renbot/multichain:latest
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,24 +6,20 @@ RUN apt upgrade -y
 
 RUN wget -c https://golang.org/dl/go1.14.6.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.14.6.linux-amd64.tar.gz
-ENV PATH=$PATH:/usr/local/go/bin
 
-RUN export GOROOT=/usr/local/go && \
-    export GOPATH=$HOME/go && \
-    export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
-
-RUN mkdir -p $(go env GOPATH) && \
-	cd $(go env GOPATH) && \
-	ls && \
-	mkdir -p src/github.com/filecoin-project && \
-	cd src/github.com/filecoin-project && \
-	git clone https://github.com/filecoin-project/filecoin-ffi && \
-	cd filecoin-ffi && \
-	git checkout a62d00da59d1b0fb && \
-	make && \
-	go install
-
+ENV GOROOT=/usr/local/go
+ENV GOPATH=$HOME/go
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 ENV GO111MODULE=on
 ENV GOPROXY=direct
 ENV GOSUMDB=off
-ENV GOPRIVATE=github.com/renproject/darknode
+
+RUN mkdir -p $(go env GOPATH)
+WORKDIR $GOPATH
+RUN mkdir -p src/github.com/filecoin-project
+WORKDIR $GOPATH/src/github.com/filecoin-project
+RUN git clone https://github.com/filecoin-project/filecoin-ffi
+WORKDIR $GOPATH/src/github.com/filecoin-project/filecoin-ffi
+RUN git checkout a62d00da59d1b0fb
+RUN make
+RUN go install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:bionic
+
+RUN apt update -y
+RUN apt install -y mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl wget
+RUN apt upgrade -y
+
+RUN wget -c https://golang.org/dl/go1.14.6.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.14.6.linux-amd64.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin
+
+RUN export GOROOT=/usr/local/go && \
+    export GOPATH=$HOME/go && \
+    export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+RUN mkdir -p $(go env GOPATH) && \
+	cd $(go env GOPATH) && \
+	ls && \
+	mkdir -p src/github.com/filecoin-project && \
+	cd src/github.com/filecoin-project && \
+	git clone https://github.com/filecoin-project/filecoin-ffi && \
+	cd filecoin-ffi && \
+	git checkout a62d00da59d1b0fb && \
+	make && \
+	go install

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,8 @@ RUN mkdir -p $(go env GOPATH) && \
 	git checkout a62d00da59d1b0fb && \
 	make && \
 	go install
+
+ENV GO111MODULE=on
+ENV GOPROXY=direct
+ENV GOSUMDB=off
+ENV GOPRIVATE=github.com/renproject/darknode


### PR DESCRIPTION
Create a base docker image for Multichain that can be re-used by any other service that depends on the multichain packages.

DockerHub repo [here](https://hub.docker.com/r/renbot/multichain)