### PR TITLE
Round up sats per byte

### DIFF
--- a/chain/bitcoin/gas.go
+++ b/chain/bitcoin/gas.go
@@ -2,6 +2,7 @@ package bitcoin
 
 import (
 	"context"
+	"math"
 
 	"github.com/renproject/pack"
 )
@@ -44,6 +45,6 @@ func (gasEstimator GasEstimator) EstimateGas(ctx context.Context) (pack.U256, pa
 		return pack.NewU256([32]byte{}), pack.NewU256([32]byte{}), err
 	}
 
-	satsPerByte := uint64(feeRate * btcToSatoshis / kilobyteToByte)
-	return pack.NewU256FromU64(pack.NewU64(satsPerByte)), pack.NewU256FromU64(pack.NewU64(satsPerByte)), nil
+	satsPerByte := uint64(math.Ceil(feeRate * btcToSatoshis / kilobyteToByte))
+	return pack.NewU256FromUint64(satsPerByte), pack.NewU256FromUint64(satsPerByte), nil
 }


### PR DESCRIPTION
The Bitcoin gas estimation currently fails when the `feeRate` returned by the Bitcoin node is less than `1024/1e8`. This is because of the sats/byte calculation which truncates the result of `feeRate * btcToSatoshis / kilobyteToByte` by converting it directly to a `uint64`. In the case the `feeRate` is less than `0.00001024`, the resulting value (less than 1) gets rounded down to `0`, meaning any submission that uses this estimate directly is guaranteed to fail (also in the case that any multipliers are applied).

This PR updates the gas estimator to round up the sats/byte prior to returning the estimates.