### PR TITLE
Fix Cosmos payload encoding

### DIFF
--- a/chain/cosmos/tx.go
+++ b/chain/cosmos/tx.go
@@ -87,7 +87,7 @@ func (builder txBuilder) BuildTx(ctx context.Context, from, to address.Address, 
 		0,
 		false,
 		builder.chainID.String(),
-		payload.String(),
+		string(payload),
 		fees.Coins(),
 		types.DecCoins{},
 	)


### PR DESCRIPTION
Inside the `BuildTx` function for cosmos we encode the payload by calling `payload.String()`, however when decoding we simply convert the `tx.memo` string to `pack.Bytes` directly. This PR updates the encoding to be `string(payload)` so when fetching the payload, the same data is returned.