### PR TITLE
Add helper functions for fetching account balances

### DIFF
--- a/api/account/account.go
+++ b/api/account/account.go
@@ -62,6 +62,9 @@ type TxBuilder interface {
 // The Client interface defines the functionality required to interact with a
 // chain over RPC.
 type Client interface {
+	// AccountBalance returns the current balance of the given account.
+	AccountBalance(context.Context, address.Address) (pack.U256, error)
+
 	// AccountNonce is the current nonce of this account, which must be used to
 	// build a new transaction.
 	AccountNonce(context.Context, address.Address) (pack.U256, error)

--- a/chain/cosmos/client.go
+++ b/chain/cosmos/client.go
@@ -25,13 +25,15 @@ const (
 	DefaultClientTimeoutRetry = time.Second
 	// DefaultClientHost used by the Client. This should only be used for local
 	// deployments of the multichain.
-	DefaultClientHost = "http://0.0.0.0:26657"
+	DefaultClientHost = pack.String("http://0.0.0.0:26657")
 	// DefaultBroadcastMode configures the behaviour of a cosmos client while it
 	// interacts with the cosmos node. Allowed broadcast modes can be async, sync
 	// and block. "async" returns immediately after broadcasting, "sync" returns
 	// after the transaction has been checked and "block" waits until the
 	// transaction is committed to the chain.
-	DefaultBroadcastMode = "sync"
+	DefaultBroadcastMode = pack.String("sync")
+	// DefaultCoinDenom used by the Client.
+	DefaultCoinDenom = pack.String("uluna")
 )
 
 // ClientOptions are used to parameterise the behaviour of the Client.
@@ -40,6 +42,7 @@ type ClientOptions struct {
 	TimeoutRetry  time.Duration
 	Host          pack.String
 	BroadcastMode pack.String
+	CoinDenom     pack.String
 }
 
 // DefaultClientOptions returns ClientOptions with the default settings. These
@@ -49,14 +52,40 @@ func DefaultClientOptions() ClientOptions {
 	return ClientOptions{
 		Timeout:       DefaultClientTimeout,
 		TimeoutRetry:  DefaultClientTimeoutRetry,
-		Host:          pack.String(DefaultClientHost),
-		BroadcastMode: pack.String(DefaultBroadcastMode),
+		Host:          DefaultClientHost,
+		BroadcastMode: DefaultBroadcastMode,
+		CoinDenom:     DefaultCoinDenom,
 	}
 }
 
-// WithHost sets the URL of the Bitcoin node.
+// WithTimeout sets the timeout used by the Client.
+func (opts ClientOptions) WithTimeout(timeout time.Duration) ClientOptions {
+	opts.Timeout = timeout
+	return opts
+}
+
+// WithTimeoutRetry sets the timeout retry used by the Client.
+func (opts ClientOptions) WithTimeoutRetry(timeoutRetry time.Duration) ClientOptions {
+	opts.TimeoutRetry = timeoutRetry
+	return opts
+}
+
+// WithHost sets the URL of the node.
 func (opts ClientOptions) WithHost(host pack.String) ClientOptions {
 	opts.Host = host
+	return opts
+}
+
+// WithBroadcastMode sets the behaviour of the Client when interacting with the
+// underlying node.
+func (opts ClientOptions) WithBroadcastMode(broadcastMode pack.String) ClientOptions {
+	opts.BroadcastMode = broadcastMode
+	return opts
+}
+
+// WithCoinDenom sets the coin denomination used by the Client.
+func (opts ClientOptions) WithCoinDenom(coinDenom pack.String) ClientOptions {
+	opts.CoinDenom = coinDenom
 	return opts
 }
 
@@ -157,7 +186,7 @@ func (client *Client) AccountNumber(_ context.Context, addr address.Address) (pa
 }
 
 // AccountBalance returns the account balancee for a given address.
-func (client *Client) AccountBalance(_ context.Context, addr address.Address, denom string) (pack.U256, error) {
+func (client *Client) AccountBalance(_ context.Context, addr address.Address) (pack.U256, error) {
 	cosmosAddr, err := types.AccAddressFromBech32(string(addr))
 	if err != nil {
 		return pack.U256{}, fmt.Errorf("bad address: '%v': %v", addr, err)
@@ -169,7 +198,7 @@ func (client *Client) AccountBalance(_ context.Context, addr address.Address, de
 		return pack.U256{}, err
 	}
 
-	balance := acc.GetCoins().AmountOf(denom).BigInt()
+	balance := acc.GetCoins().AmountOf(string(client.opts.CoinDenom)).BigInt()
 
 	// If the balance exceeds `MaxU256`, return an error.
 	if pack.MaxU256.Int().Cmp(balance) == -1 {

--- a/chain/cosmos/tx.go
+++ b/chain/cosmos/tx.go
@@ -19,16 +19,32 @@ import (
 	"github.com/tendermint/tendermint/crypto/tmhash"
 )
 
-type txBuilder struct {
-	client    *Client
-	coinDenom pack.String
-	chainID   pack.String
-}
+const (
+	// DefaultChainID used by the Client.
+	DefaultChainID = pack.String("testnet")
+)
 
 // TxBuilderOptions only contains necessary options to build tx from tx builder
 type TxBuilderOptions struct {
-	ChainID   pack.String `json:"chain_id"`
-	CoinDenom pack.String `json:"coin_denom"`
+	ChainID pack.String
+}
+
+// DefaultTxBuilderOptions returns TxBuilderOptions with the default settings.
+func DefaultTxBuilderOptions() TxBuilderOptions {
+	return TxBuilderOptions{
+		ChainID: DefaultChainID,
+	}
+}
+
+// WithChainID sets the chain ID used by the transaction builder.
+func (opts TxBuilderOptions) WithChainID(chainID pack.String) TxBuilderOptions {
+	opts.ChainID = chainID
+	return opts
+}
+
+type txBuilder struct {
+	client  *Client
+	chainID pack.String
 }
 
 // NewTxBuilder returns an implementation of the transaction builder interface
@@ -40,9 +56,8 @@ func NewTxBuilder(options TxBuilderOptions, client *Client) account.TxBuilder {
 	}
 
 	return txBuilder{
-		client:    client,
-		coinDenom: options.CoinDenom,
-		chainID:   options.ChainID,
+		client:  client,
+		chainID: options.ChainID,
 	}
 }
 
@@ -63,14 +78,16 @@ func (builder txBuilder) BuildTx(ctx context.Context, from, to address.Address, 
 	sendMsg := MsgSend{
 		FromAddress: Address(fromAddr),
 		ToAddress:   Address(toAddr),
-		Amount: []Coin{Coin{
-			Denom:  builder.coinDenom,
-			Amount: pack.NewU64(value.Int().Uint64()),
-		}},
+		Amount: []Coin{
+			{
+				Denom:  builder.client.opts.CoinDenom,
+				Amount: pack.NewU64(value.Int().Uint64()),
+			},
+		},
 	}
 
 	fees := Coins{Coin{
-		Denom:  builder.coinDenom,
+		Denom:  builder.client.opts.CoinDenom,
 		Amount: pack.NewU64(gasPrice.Mul(gasLimit).Int().Uint64()),
 	}}
 

--- a/chain/filecoin/client.go
+++ b/chain/filecoin/client.go
@@ -167,3 +167,25 @@ func (client *Client) AccountNonce(ctx context.Context, addr address.Address) (p
 
 	return pack.NewU256FromU64(pack.NewU64(actor.Nonce)), nil
 }
+
+// AccountBalance returns the account balancee for a given address.
+func (client *Client) AccountBalance(ctx context.Context, addr address.Address) (pack.U256, error) {
+	filAddr, err := filaddress.NewFromString(string(addr))
+	if err != nil {
+		return pack.U256{}, fmt.Errorf("bad address '%v': %v", addr, err)
+	}
+
+	actor, err := client.node.StateGetActor(ctx, filAddr, types.NewTipSetKey(cid.Undef))
+	if err != nil {
+		return pack.U256{}, fmt.Errorf("searching state for addr: %v", addr)
+	}
+
+	balance := actor.Balance.Int
+
+	// If the balance exceeds `MaxU256`, return an error.
+	if pack.MaxU256.Int().Cmp(balance) == -1 {
+		return pack.U256{}, fmt.Errorf("balance %v for %v exceeds MaxU256", balance.String(), addr)
+	}
+
+	return pack.NewU256FromInt(balance), nil
+}

--- a/chain/terra/terra.go
+++ b/chain/terra/terra.go
@@ -18,14 +18,17 @@ type (
 )
 
 var (
-	// DefaultClientOptions re-exports default cosmos-compatible client options
+	// DefaultClientOptions re-exports cosmos.DefaultClientOptions
 	DefaultClientOptions = cosmos.DefaultClientOptions
+
+	// DefaultTxBuilderOptions re-exports cosmos.DefaultTxBuilderOptions
+	DefaultTxBuilderOptions = cosmos.DefaultTxBuilderOptions
 
 	// NewGasEstimator re-exports cosmos.NewGasEstimator
 	NewGasEstimator = cosmos.NewGasEstimator
 )
 
-// NewClient returns returns a new Client with terra codec
+// NewClient returns returns a new Client with Terra codec.
 func NewClient(opts ClientOptions) *Client {
 	return cosmos.NewClient(opts, app.MakeCodec())
 }

--- a/chain/terra/terra_test.go
+++ b/chain/terra/terra_test.go
@@ -53,15 +53,19 @@ var _ = Describe("Terra", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// instantiate a new client
-				client := terra.NewClient(terra.DefaultClientOptions())
+				client := terra.NewClient(
+					terra.DefaultClientOptions().
+						WithCoinDenom("uluna"),
+				)
 				nonce, err := client.AccountNonce(ctx, multichain.Address(addr.String()))
 				Expect(err).NotTo(HaveOccurred())
 
 				// create a new cosmos-compatible transaction builder
-				txBuilder := terra.NewTxBuilder(terra.TxBuilderOptions{
-					ChainID:   "testnet",
-					CoinDenom: "uluna",
-				}, client)
+				txBuilder := terra.NewTxBuilder(
+					terra.DefaultTxBuilderOptions().
+						WithChainID("testnet"),
+					client,
+				)
 
 				// build the transaction
 				payload := pack.NewBytes([]byte("multichain"))

--- a/multichain_test.go
+++ b/multichain_test.go
@@ -346,12 +346,14 @@ var _ = Describe("Multichain", func() {
 				func(rpcURL pack.String) (multichain.AccountClient, multichain.AccountTxBuilder) {
 					client := terra.NewClient(
 						terra.DefaultClientOptions().
-							WithHost(rpcURL),
+							WithHost(rpcURL).
+							WithCoinDenom("uluna"),
 					)
-					txBuilder := terra.NewTxBuilder(terra.TxBuilderOptions{
-						ChainID:   "testnet",
-						CoinDenom: "uluna",
-					}, client)
+					txBuilder := terra.NewTxBuilder(
+						terra.DefaultTxBuilderOptions().
+							WithChainID("testnet"),
+						client,
+					)
 
 					return client, txBuilder
 				},


### PR DESCRIPTION
This PR updates the Filecoin and Terra clients to expose an `AccountBalance` function that returns the balance of a given account. This is currently possible for UTXO-based clients through the `UnspentOutputs` function (for imported addresses), however hasn't been possible for account-based clients until now.

We could also potentially update the account client API to make this a requirement.

EDIT: The `AccountBalance` function has been added to the account client API.