### PR TITLE
fix: set prefix in cosmos client

### DIFF
--- a/chain/cosmos/client.go
+++ b/chain/cosmos/client.go
@@ -66,10 +66,11 @@ type Client struct {
 	opts   ClientOptions
 	cliCtx cliContext.CLIContext
 	cdc    *codec.Codec
+	hrp    string
 }
 
 // NewClient returns a new Client.
-func NewClient(opts ClientOptions, cdc *codec.Codec) *Client {
+func NewClient(opts ClientOptions, cdc *codec.Codec, hrp string) *Client {
 	httpClient, err := rpchttp.NewWithTimeout(opts.Host.String(), "websocket", uint(opts.Timeout/time.Second))
 	if err != nil {
 		panic(err)
@@ -81,6 +82,7 @@ func NewClient(opts ClientOptions, cdc *codec.Codec) *Client {
 		opts:   opts,
 		cliCtx: cliCtx,
 		cdc:    cdc,
+		hrp:    hrp,
 	}
 }
 
@@ -126,6 +128,8 @@ func (client *Client) SubmitTx(ctx context.Context, tx account.Tx) error {
 // AccountNonce returns the current nonce of the account. This is the nonce to
 // be used while building a new transaction.
 func (client *Client) AccountNonce(_ context.Context, addr address.Address) (pack.U256, error) {
+	types.GetConfig().SetBech32PrefixForAccount(client.hrp, client.hrp+"pub")
+
 	cosmosAddr, err := types.AccAddressFromBech32(string(addr))
 	if err != nil {
 		return pack.U256{}, fmt.Errorf("bad address: '%v': %v", addr, err)
@@ -142,6 +146,8 @@ func (client *Client) AccountNonce(_ context.Context, addr address.Address) (pac
 
 // AccountNumber returns the account number for a given address.
 func (client *Client) AccountNumber(_ context.Context, addr address.Address) (pack.U64, error) {
+	types.GetConfig().SetBech32PrefixForAccount(client.hrp, client.hrp+"pub")
+
 	cosmosAddr, err := types.AccAddressFromBech32(string(addr))
 	if err != nil {
 		return 0, fmt.Errorf("bad address: '%v': %v", addr, err)

--- a/chain/cosmos/tx.go
+++ b/chain/cosmos/tx.go
@@ -50,6 +50,8 @@ func NewTxBuilder(options TxBuilderOptions, client *Client) account.TxBuilder {
 // This transaction is unsigned, and must be signed before submitting to the
 // cosmos chain.
 func (builder txBuilder) BuildTx(ctx context.Context, from, to address.Address, value, nonce, gasLimit, gasPrice, gasCap pack.U256, payload pack.Bytes) (account.Tx, error) {
+	types.GetConfig().SetBech32PrefixForAccount(builder.client.hrp, builder.client.hrp+"pub")
+
 	fromAddr, err := types.AccAddressFromBech32(string(from))
 	if err != nil {
 		return nil, err

--- a/chain/terra/terra.go
+++ b/chain/terra/terra.go
@@ -27,7 +27,7 @@ var (
 
 // NewClient returns returns a new Client with terra codec
 func NewClient(opts ClientOptions) *Client {
-	return cosmos.NewClient(opts, app.MakeCodec())
+	return cosmos.NewClient(opts, app.MakeCodec(), "terra")
 }
 
 // NewTxBuilder returns an implementation of the transaction builder interface


### PR DESCRIPTION
This PR adds a field `hrp` in `cosmos.Client`. This helps us in potentially supporting multiple cosmos-chains in the future, as we globally set the `prefix` before doing any operation.