### PR TITLE
UTXO Gas Estimation

### DIFF
--- a/chain/bitcoin/bitcoin.go
+++ b/chain/bitcoin/bitcoin.go
@@ -90,6 +90,8 @@ type Client interface {
 	Confirmations(ctx context.Context, txHash pack.Bytes) (int64, error)
 	// EstimateSmartFee
 	EstimateSmartFee(ctx context.Context, numBlocks int64) (float64, error)
+	// EstimateFeeLegacy
+	EstimateFeeLegacy(ctx context.Context, numBlocks int64) (float64, error)
 }
 
 type client struct {
@@ -257,6 +259,23 @@ func (client *client) EstimateSmartFee(ctx context.Context, numBlocks int64) (fl
 	}
 
 	return *resp.FeeRate, nil
+}
+
+func (client *client) EstimateFeeLegacy(ctx context.Context, numBlocks int64) (float64, error) {
+	var resp float64
+
+	switch numBlocks {
+	case int64(0):
+		if err := client.send(ctx, &resp, "estimatefee"); err != nil {
+			return 0.0, fmt.Errorf("estimating fee: %v", err)
+		}
+	default:
+		if err := client.send(ctx, &resp, "estimatefee", numBlocks); err != nil {
+			return 0.0, fmt.Errorf("estimating fee: %v", err)
+		}
+	}
+
+	return resp, nil
 }
 
 func (client *client) send(ctx context.Context, resp interface{}, method string, params ...interface{}) error {

--- a/chain/bitcoin/gas_test.go
+++ b/chain/bitcoin/gas_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/renproject/multichain/chain/bitcoin"
+	"github.com/renproject/pack"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -18,23 +19,34 @@ var _ = Describe("Gas", func() {
 			client := bitcoin.NewClient(bitcoin.DefaultClientOptions())
 
 			// estimate fee to include tx within 1 block.
-			gasEstimator1 := bitcoin.NewGasEstimator(client, 1)
+			fallback1 := uint64(123)
+			gasEstimator1 := bitcoin.NewGasEstimator(client, 1, pack.NewU256FromUint64(fallback1))
 			gasPrice1, _, err := gasEstimator1.EstimateGas(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			if err != nil {
+				Expect(gasPrice1).To(Equal(pack.NewU256FromUint64(fallback1)))
+			}
 
 			// estimate fee to include tx within 10 blocks.
-			gasEstimator2 := bitcoin.NewGasEstimator(client, 10)
+			fallback2 := uint64(234)
+			gasEstimator2 := bitcoin.NewGasEstimator(client, 10, pack.NewU256FromUint64(fallback2))
 			gasPrice2, _, err := gasEstimator2.EstimateGas(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			if err != nil {
+				Expect(gasPrice2).To(Equal(pack.NewU256FromUint64(fallback2)))
+			}
 
 			// estimate fee to include tx within 100 blocks.
-			gasEstimator3 := bitcoin.NewGasEstimator(client, 100)
+			fallback3 := uint64(345)
+			gasEstimator3 := bitcoin.NewGasEstimator(client, 100, pack.NewU256FromUint64(fallback3))
 			gasPrice3, _, err := gasEstimator3.EstimateGas(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			if err != nil {
+				Expect(gasPrice3).To(Equal(pack.NewU256FromUint64(fallback3)))
+			}
 
 			// expect fees in this order at the very least.
-			Expect(gasPrice1.GreaterThanEqual(gasPrice2)).To(BeTrue())
-			Expect(gasPrice2.GreaterThanEqual(gasPrice3)).To(BeTrue())
+			if err == nil {
+				Expect(gasPrice1.GreaterThanEqual(gasPrice2)).To(BeTrue())
+				Expect(gasPrice2.GreaterThanEqual(gasPrice3)).To(BeTrue())
+			}
 		})
 	})
 })

--- a/chain/bitcoincash/gas.go
+++ b/chain/bitcoincash/gas.go
@@ -1,14 +1,54 @@
 package bitcoincash
 
-import "github.com/renproject/multichain/chain/bitcoin"
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/renproject/pack"
+)
+
+const (
+	bchToSatoshis  = 1e8
+	kilobyteToByte = 1024
+)
 
 // A GasEstimator returns the SATs-per-byte that is needed in order to confirm
 // transactions with an estimated maximum delay of one block. In distributed
 // networks that collectively build, sign, and submit transactions, it is
 // important that all nodes in the network have reached consensus on the
 // SATs-per-byte.
-type GasEstimator = bitcoin.GasEstimator
+type GasEstimator struct {
+	client      Client
+	fallbackGas pack.U256
+}
 
 // NewGasEstimator returns a simple gas estimator that always returns the given
 // number of SATs-per-byte.
-var NewGasEstimator = bitcoin.NewGasEstimator
+func NewGasEstimator(client Client, fallbackGas pack.U256) GasEstimator {
+	return GasEstimator{
+		client:      client,
+		fallbackGas: fallbackGas,
+	}
+}
+
+// EstimateGas returns the number of SATs-per-byte (for both price and cap) that
+// is needed in order to confirm transactions with a minimal delay. It is the
+// responsibility of the caller to know the number of bytes in their
+// transaction. This method calls the `estimatefee` RPC call to the node, which
+// based on a conservative (considering longer history) strategy returns the
+// estimated BCH per kilobyte of data in the transaction. An error will be
+// returned if the node hasn't observed enough blocks to make an estimate.
+func (gasEstimator GasEstimator) EstimateGas(ctx context.Context) (pack.U256, pack.U256, error) {
+	feeRate, err := gasEstimator.client.EstimateFeeLegacy(ctx, int64(0))
+	if err != nil {
+		return gasEstimator.fallbackGas, gasEstimator.fallbackGas, err
+	}
+
+	if feeRate <= 0.0 {
+		return gasEstimator.fallbackGas, gasEstimator.fallbackGas, fmt.Errorf("invalid fee rate: %v", feeRate)
+	}
+
+	satsPerByte := uint64(math.Ceil(feeRate * bchToSatoshis / kilobyteToByte))
+	return pack.NewU256FromUint64(satsPerByte), pack.NewU256FromUint64(satsPerByte), nil
+}

--- a/chain/bitcoincash/gas_test.go
+++ b/chain/bitcoincash/gas_test.go
@@ -1,1 +1,31 @@
 package bitcoincash_test
+
+import (
+	"context"
+
+	"github.com/renproject/multichain/chain/bitcoincash"
+	"github.com/renproject/pack"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Gas", func() {
+	Context("when estimating bitcoincash network fee", func() {
+		It("should work", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			client := bitcoincash.NewClient(bitcoincash.DefaultClientOptions())
+
+			fallbackGas := uint64(123)
+			gasEstimator := bitcoincash.NewGasEstimator(client, pack.NewU256FromUint64(fallbackGas))
+			gasPrice, _, err := gasEstimator.EstimateGas(ctx)
+			if err != nil {
+				Expect(gasPrice).To(Equal(pack.NewU256FromUint64(fallbackGas)))
+			} else {
+				Expect(gasPrice.Int().Uint64()).To(BeNumerically(">", 0))
+			}
+		})
+	})
+})

--- a/chain/dogecoin/gas_test.go
+++ b/chain/dogecoin/gas_test.go
@@ -1,1 +1,52 @@
 package dogecoin_test
+
+import (
+	"context"
+
+	"github.com/renproject/multichain/chain/dogecoin"
+	"github.com/renproject/pack"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Gas", func() {
+	Context("when estimating dogecoin network fee", func() {
+		It("should work", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			client := dogecoin.NewClient(dogecoin.DefaultClientOptions())
+
+			// estimate fee to include tx within 1 block.
+			fallback1 := uint64(123)
+			gasEstimator1 := dogecoin.NewGasEstimator(client, 1, pack.NewU256FromUint64(fallback1))
+			gasPrice1, _, err := gasEstimator1.EstimateGas(ctx)
+			if err != nil {
+				Expect(gasPrice1).To(Equal(pack.NewU256FromUint64(fallback1)))
+			}
+
+			// estimate fee to include tx within 10 blocks.
+			fallback2 := uint64(234)
+			gasEstimator2 := dogecoin.NewGasEstimator(client, 10, pack.NewU256FromUint64(fallback2))
+			gasPrice2, _, err := gasEstimator2.EstimateGas(ctx)
+			if err != nil {
+				Expect(gasPrice2).To(Equal(pack.NewU256FromUint64(fallback2)))
+			}
+
+			// estimate fee to include tx within 100 blocks.
+			fallback3 := uint64(345)
+			gasEstimator3 := dogecoin.NewGasEstimator(client, 100, pack.NewU256FromUint64(fallback3))
+			gasPrice3, _, err := gasEstimator3.EstimateGas(ctx)
+			if err != nil {
+				Expect(gasPrice3).To(Equal(pack.NewU256FromUint64(fallback3)))
+			}
+
+			// expect fees in this order at the very least.
+			if err == nil {
+				Expect(gasPrice1.GreaterThanEqual(gasPrice2)).To(BeTrue())
+				Expect(gasPrice2.GreaterThanEqual(gasPrice3)).To(BeTrue())
+			}
+		})
+	})
+})

--- a/chain/zcash/gas.go
+++ b/chain/zcash/gas.go
@@ -1,9 +1,57 @@
 package zcash
 
-import "github.com/renproject/multichain/chain/bitcoin"
+import (
+	"context"
+	"fmt"
+	"math"
 
-// GasEstimator re-exports bitcoin.GasEstimator
-type GasEstimator = bitcoin.GasEstimator
+	"github.com/renproject/pack"
+)
 
-// NewGasEstimator re-exports bitcoin.NewGasEstimator
-var NewGasEstimator = bitcoin.NewGasEstimator
+const (
+	multiplier     = 1e8
+	kilobyteToByte = 1024
+)
+
+// A GasEstimator returns the SATs-per-byte that is needed in order to confirm
+// transactions with an estimated maximum delay of one block. In distributed
+// networks that collectively build, sign, and submit transactions, it is
+// important that all nodes in the network have reached consensus on the
+// SATs-per-byte.
+type GasEstimator struct {
+	client      Client
+	numBlocks   int64
+	fallbackGas pack.U256
+}
+
+// NewGasEstimator returns a simple gas estimator that always returns the given
+// number of SATs-per-byte.
+func NewGasEstimator(client Client, numBlocks int64, fallbackGas pack.U256) GasEstimator {
+	return GasEstimator{
+		client:      client,
+		numBlocks:   numBlocks,
+		fallbackGas: fallbackGas,
+	}
+}
+
+// EstimateGas returns the number of SATs-per-byte (for both price and cap) that
+// is needed in order to confirm transactions with an estimated maximum delay of
+// `numBlocks` block. It is the responsibility of the caller to know the number
+// of bytes in their transaction. This method calls the `estimatesmartfee` RPC
+// call to the node, which based on a conservative (considering longer history)
+// strategy returns the estimated BTC per kilobyte of data in the transaction.
+// An error will be returned if the bitcoin node hasn't observed enough blocks
+// to make an estimate for the provided target `numBlocks`.
+func (gasEstimator GasEstimator) EstimateGas(ctx context.Context) (pack.U256, pack.U256, error) {
+	feeRate, err := gasEstimator.client.EstimateFeeLegacy(ctx, gasEstimator.numBlocks)
+	if err != nil {
+		return gasEstimator.fallbackGas, gasEstimator.fallbackGas, err
+	}
+
+	if feeRate <= 0.0 {
+		return gasEstimator.fallbackGas, gasEstimator.fallbackGas, fmt.Errorf("invalid fee rate: %v", feeRate)
+	}
+
+	satsPerByte := uint64(math.Ceil(feeRate * multiplier / kilobyteToByte))
+	return pack.NewU256FromUint64(satsPerByte), pack.NewU256FromUint64(satsPerByte), nil
+}

--- a/chain/zcash/gas_test.go
+++ b/chain/zcash/gas_test.go
@@ -1,1 +1,52 @@
 package zcash_test
+
+import (
+	"context"
+
+	"github.com/renproject/multichain/chain/zcash"
+	"github.com/renproject/pack"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Gas", func() {
+	Context("when estimating zcash network fee", func() {
+		It("should work", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			client := zcash.NewClient(zcash.DefaultClientOptions())
+
+			// estimate fee to include tx within 1 block.
+			fallback1 := uint64(123)
+			gasEstimator1 := zcash.NewGasEstimator(client, 1, pack.NewU256FromUint64(fallback1))
+			gasPrice1, _, err := gasEstimator1.EstimateGas(ctx)
+			if err != nil {
+				Expect(gasPrice1).To(Equal(pack.NewU256FromUint64(fallback1)))
+			}
+
+			// estimate fee to include tx within 10 blocks.
+			fallback2 := uint64(234)
+			gasEstimator2 := zcash.NewGasEstimator(client, 10, pack.NewU256FromUint64(fallback2))
+			gasPrice2, _, err := gasEstimator2.EstimateGas(ctx)
+			if err != nil {
+				Expect(gasPrice2).To(Equal(pack.NewU256FromUint64(fallback2)))
+			}
+
+			// estimate fee to include tx within 100 blocks.
+			fallback3 := uint64(345)
+			gasEstimator3 := zcash.NewGasEstimator(client, 100, pack.NewU256FromUint64(fallback3))
+			gasPrice3, _, err := gasEstimator3.EstimateGas(ctx)
+			if err != nil {
+				Expect(gasPrice3).To(Equal(pack.NewU256FromUint64(fallback3)))
+			}
+
+			// expect fees in this order at the very least.
+			if err == nil {
+				Expect(gasPrice1.GreaterThanEqual(gasPrice2)).To(BeTrue())
+				Expect(gasPrice2.GreaterThanEqual(gasPrice3)).To(BeTrue())
+			}
+		})
+	})
+})

--- a/infra/zcash/Dockerfile
+++ b/infra/zcash/Dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:bionic
 
 # Install zcashd.
-RUN apt-get update                                                                             && \
-    apt-get install -y --no-install-recommends apt-transport-https gnupg2 ca-certificates wget && \
-    wget -qO - https://apt.z.cash/zcash.asc | apt-key add -                                    && \
-    echo "deb https://apt.z.cash/ jessie main" | tee /etc/apt/sources.list.d/zcash.list        && \
-    apt-get update && apt-get install -y --no-install-recommends zcash                         && \
+RUN apt-get update                                                                                    && \
+    apt-get install -y --no-install-recommends apt-transport-https gnupg2 ca-certificates wget        && \
+    wget -qO - https://apt.z.cash/zcash.asc | apt-key add -                                           && \
+    echo "deb [arch=amd64] https://apt.z.cash/ stretch main" | tee /etc/apt/sources.list.d/zcash.list && \
+    apt-get update && apt-get install -y --no-install-recommends zcash                                && \
     mkdir -p /root/.zcash-params && zcash-fetch-params
 
 COPY zcash.conf /root/.zcash/zcash.conf

--- a/infra/zcash/run.sh
+++ b/infra/zcash/run.sh
@@ -2,7 +2,13 @@
 ADDRESS=$1
 
 # Start
-zcashd -mineraddress=$ADDRESS
+zcashd \
+  -mineraddress=$ADDRESS \
+  -nuparams=5ba81b19:10  \
+  -nuparams=76b809bb:20  \
+  -nuparams=2bb40e60:30  \
+  -nuparams=f5b9230b:40  \
+  -nuparams=e9ff75a6:50
 sleep 10
 
 echo "ZCASH_ADDRESS=$ADDRESS"

--- a/infra/zcash/zcash.conf
+++ b/infra/zcash/zcash.conf
@@ -8,14 +8,3 @@ server=1
 txindex=1
 gen=1
 minetolocalwallet=0
-
-# Overwinter
-nuparams=5ba81b19:10
-# Sapling
-nuparams=76b809bb:20
-# Blossom
-nuparams=2bb40e60:30
-# Heartwood
-nuparams=f5b9230b:40
-# Canopy
-nuparams=e9ff75a6:50

--- a/multichain_test.go
+++ b/multichain_test.go
@@ -593,27 +593,27 @@ var _ = Describe("Multichain", func() {
 				dogecoin.NewTxBuilder(&dogecoin.RegressionNetParams),
 				multichain.Dogecoin,
 			},
-			/*
-				{
-					"ZCASH_PK",
-					func(pkh []byte) (btcutil.Address, error) {
-						addr, err := zcash.NewAddressPubKeyHash(pkh, &zcash.RegressionNetParams)
-						return addr, err
-					},
-					func(script []byte) (btcutil.Address, error) {
-						addr, err := zcash.NewAddressScriptHash(script, &zcash.RegressionNetParams)
-						return addr, err
-					},
-					pack.String("http://0.0.0.0:18232"),
-					func(rpcURL pack.String, pkhAddr btcutil.Address) (multichain.UTXOClient, []multichain.UTXOutput, func(context.Context, pack.Bytes) (int64, error)) {
-						client := zcash.NewClient(zcash.DefaultClientOptions())
-						outputs, err := client.UnspentOutputs(ctx, 0, 999999999, multichain.Address(pkhAddr.EncodeAddress()))
-						Expect(err).NotTo(HaveOccurred())
-						return client, outputs, client.Confirmations
-					},
-					zcash.NewTxBuilder(&zcash.RegressionNetParams, 1000000),
-					multichain.Zcash,
+			{
+				"ZCASH_PK",
+				func(pkh []byte) (btcutil.Address, error) {
+					addr, err := zcash.NewAddressPubKeyHash(pkh, &zcash.RegressionNetParams)
+					return addr, err
 				},
+				func(script []byte) (btcutil.Address, error) {
+					addr, err := zcash.NewAddressScriptHash(script, &zcash.RegressionNetParams)
+					return addr, err
+				},
+				pack.String("http://0.0.0.0:18232"),
+				func(rpcURL pack.String, pkhAddr btcutil.Address) (multichain.UTXOClient, []multichain.UTXOutput, func(context.Context, pack.Bytes) (int64, error)) {
+					client := zcash.NewClient(zcash.DefaultClientOptions())
+					outputs, err := client.UnspentOutputs(ctx, 0, 999999999, multichain.Address(pkhAddr.EncodeAddress()))
+					Expect(err).NotTo(HaveOccurred())
+					return client, outputs, client.Confirmations
+				},
+				zcash.NewTxBuilder(&zcash.RegressionNetParams, 1000000),
+				multichain.Zcash,
+			},
+			/*
 				{
 					"DIGIBYTE_PK",
 					func(pkh []byte) (btcutil.Address, error) {


### PR DESCRIPTION
This PR includes:
* Handle Gas API for BitcoinCash and Zcash differently than Bitcoin/Dogecoin/DigiByte
* Add `EstimateFeeLegacy` that calls the `estimatefee` RPC call instead of `estimatesmartfee`
* Add tests for Gas API for all UTXO chains
* Upgrade Zcash infra [ref](https://forum.zcashcommunity.com/t/end-of-debian-jessie-support-is-on-october-1st-2020/37313) (We can now include Zcash in our Multichain test suite)

The Gas API for UTXO chains will now return `fallbackGas` if there was an error while estimating gas, or invalid fee rates were returned from the node.