### PR TITLE
ci: use golang base image instead of ubuntu for smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,9 @@
-FROM ubuntu:bionic
+FROM golang
 
 RUN apt update -y
 RUN apt install -y mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl wget
 RUN apt upgrade -y
 
-RUN wget -c https://golang.org/dl/go1.14.6.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.14.6.linux-amd64.tar.gz
-
-ENV GOROOT=/usr/local/go
-ENV GOPATH=$HOME/go
-ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 ENV GO111MODULE=on
 ENV GOPROXY=direct
 ENV GOSUMDB=off


### PR DESCRIPTION
This PR creates `multichain` image on top of `golang` instead of `ubuntu:bionic`. This means the overall image is much smaller and takes less time to be built. No change is required in other repositories that rely on `renbot/multichain:latest`.