### PR TITLE
fix(ci): use proxy to download packages faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN apt install -y mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config 
 RUN apt upgrade -y
 
 ENV GO111MODULE=on
-ENV GOPROXY=direct
-ENV GOSUMDB=off
+ENV GOPROXY=https://proxy.golang.org
 
 RUN mkdir -p $(go env GOPATH)
 WORKDIR $GOPATH


### PR DESCRIPTION
Original fix was added here: https://github.com/renproject/lightnode/pull/108

This PR uses the same fix but in multichain so that the dependant images don't need to set it.