### PR TITLE
Fix Cosmos config initialisation

### DIFF
--- a/chain/cosmos/address.go
+++ b/chain/cosmos/address.go
@@ -28,37 +28,34 @@ type AddressEncodeDecoder struct {
 }
 
 // NewAddressEncodeDecoder creates a new address encoder-decoder
-func NewAddressEncodeDecoder(hrp string) AddressEncodeDecoder {
+func NewAddressEncodeDecoder() AddressEncodeDecoder {
 	return AddressEncodeDecoder{
-		AddressEncoder: NewAddressEncoder(hrp),
-		AddressDecoder: NewAddressDecoder(hrp),
+		AddressEncoder: NewAddressEncoder(),
+		AddressDecoder: NewAddressDecoder(),
 	}
 }
 
 // AddressEncoder implements the address.Encoder interface
 type AddressEncoder struct {
-	hrp string
 }
 
 // AddressDecoder implements the address.Decoder interface
 type AddressDecoder struct {
-	hrp string
 }
 
 // NewAddressDecoder creates a new address decoder
-func NewAddressDecoder(hrp string) AddressDecoder {
-	return AddressDecoder{hrp: hrp}
+func NewAddressDecoder() AddressDecoder {
+	return AddressDecoder{}
 }
 
 // NewAddressEncoder creates a new address encoder
-func NewAddressEncoder(hrp string) AddressEncoder {
-	return AddressEncoder{hrp: hrp}
+func NewAddressEncoder() AddressEncoder {
+	return AddressEncoder{}
 }
 
 // DecodeAddress consumes a human-readable representation of a cosmos
 // compatible address and decodes it to its raw bytes representation.
 func (decoder AddressDecoder) DecodeAddress(addr address.Address) (address.RawAddress, error) {
-	sdk.GetConfig().SetBech32PrefixForAccount(decoder.hrp, decoder.hrp+"pub")
 	rawAddr, err := sdk.AccAddressFromBech32(string(addr))
 	if err != nil {
 		return nil, err
@@ -69,7 +66,6 @@ func (decoder AddressDecoder) DecodeAddress(addr address.Address) (address.RawAd
 // EncodeAddress consumes raw bytes and encodes them to a human-readable
 // address format.
 func (encoder AddressEncoder) EncodeAddress(rawAddr address.RawAddress) (address.Address, error) {
-	sdk.GetConfig().SetBech32PrefixForAccount(encoder.hrp, encoder.hrp+"pub")
 	bech32Addr := sdk.AccAddress(rawAddr)
 	return address.Address(bech32Addr.String()), nil
 }

--- a/chain/cosmos/client.go
+++ b/chain/cosmos/client.go
@@ -169,8 +169,6 @@ func (client *Client) SubmitTx(ctx context.Context, tx account.Tx) error {
 // AccountNonce returns the current nonce of the account. This is the nonce to
 // be used while building a new transaction.
 func (client *Client) AccountNonce(_ context.Context, addr address.Address) (pack.U256, error) {
-	types.GetConfig().SetBech32PrefixForAccount(client.hrp, client.hrp+"pub")
-
 	cosmosAddr, err := types.AccAddressFromBech32(string(addr))
 	if err != nil {
 		return pack.U256{}, fmt.Errorf("bad address: '%v': %v", addr, err)
@@ -187,8 +185,6 @@ func (client *Client) AccountNonce(_ context.Context, addr address.Address) (pac
 
 // AccountNumber returns the account number for a given address.
 func (client *Client) AccountNumber(_ context.Context, addr address.Address) (pack.U64, error) {
-	types.GetConfig().SetBech32PrefixForAccount(client.hrp, client.hrp+"pub")
-
 	cosmosAddr, err := types.AccAddressFromBech32(string(addr))
 	if err != nil {
 		return 0, fmt.Errorf("bad address: '%v': %v", addr, err)
@@ -205,8 +201,6 @@ func (client *Client) AccountNumber(_ context.Context, addr address.Address) (pa
 
 // AccountBalance returns the account balancee for a given address.
 func (client *Client) AccountBalance(_ context.Context, addr address.Address) (pack.U256, error) {
-	types.GetConfig().SetBech32PrefixForAccount(client.hrp, client.hrp+"pub")
-
 	cosmosAddr, err := types.AccAddressFromBech32(string(addr))
 	if err != nil {
 		return pack.U256{}, fmt.Errorf("bad address: '%v': %v", addr, err)

--- a/chain/cosmos/tx.go
+++ b/chain/cosmos/tx.go
@@ -65,8 +65,6 @@ func NewTxBuilder(options TxBuilderOptions, client *Client) account.TxBuilder {
 // This transaction is unsigned, and must be signed before submitting to the
 // cosmos chain.
 func (builder txBuilder) BuildTx(ctx context.Context, from, to address.Address, value, nonce, gasLimit, gasPrice, gasCap pack.U256, payload pack.Bytes) (account.Tx, error) {
-	types.GetConfig().SetBech32PrefixForAccount(builder.client.hrp, builder.client.hrp+"pub")
-
 	fromAddr, err := types.AccAddressFromBech32(string(from))
 	if err != nil {
 		return nil, err

--- a/chain/terra/address_test.go
+++ b/chain/terra/address_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Terra", func() {
 	Context("when decoding address", func() {
 		Context("when decoding Terra address", func() {
 			It("should work", func() {
-				decoder := terra.NewAddressDecoder("terra")
+				decoder := terra.NewAddressDecoder()
 
 				addrStr := "terra1ztez03dp94y2x55fkhmrvj37ck204geq33msma"
 				_, err := decoder.DecodeAddress(multichain.Address(pack.NewString(addrStr)))

--- a/chain/terra/terra.go
+++ b/chain/terra/terra.go
@@ -1,6 +1,7 @@
 package terra
 
 import (
+	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/renproject/multichain/api/account"
 	"github.com/renproject/multichain/chain/cosmos"
 	"github.com/terra-project/core/app"
@@ -27,6 +28,19 @@ var (
 	// NewGasEstimator re-exports cosmos.NewGasEstimator
 	NewGasEstimator = cosmos.NewGasEstimator
 )
+
+// Set the Bech32 address prefix for the globally-defined config variable inside
+// Cosmos SDK. This is required as there are a number of functions inside the
+// SDK that make use of this global config directly, instead of allowing us to
+// provide a custom config.
+func init() {
+	// TODO: This will prevent us from being able to support multiple
+	// Cosmos-compatible chains in the Multichain. This is expected to be
+	// resolved before v1.0 of the Cosmos SDK (issue being tracked here:
+	// https://github.com/cosmos/cosmos-sdk/issues/7448).
+	types.GetConfig().SetBech32PrefixForAccount("terra", "terrapub")
+	types.GetConfig().Seal()
+}
 
 // NewClient returns returns a new Client with Terra codec.
 func NewClient(opts ClientOptions) *Client {

--- a/chain/terra/terra_test.go
+++ b/chain/terra/terra_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Terra", func() {
 
 				// random recipient
 				pkRecipient := secp256k1.GenPrivKey()
-				addrEncoder := terra.NewAddressEncoder("terra")
+				addrEncoder := terra.NewAddressEncoder()
 				recipient, err := addrEncoder.EncodeAddress(address.RawAddress(pack.Bytes(pkRecipient.PubKey().Address())))
 				Expect(err).NotTo(HaveOccurred())
 

--- a/multichain_test.go
+++ b/multichain_test.go
@@ -150,7 +150,6 @@ var _ = Describe("Multichain", func() {
 				},
 				func() multichain.Address {
 					pk := secp256k1.GenPrivKey()
-					cosmossdk.GetConfig().SetBech32PrefixForAccount("terra", "terrapub")
 					addr := cosmossdk.AccAddress(pk.PubKey().Address())
 					return multichain.Address(addr.String())
 				},

--- a/multichain_test.go
+++ b/multichain_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Multichain", func() {
 			{
 				multichain.Terra,
 				func() multichain.AddressEncodeDecoder {
-					return terra.NewAddressEncodeDecoder("terra")
+					return terra.NewAddressEncodeDecoder()
 				},
 				func() multichain.Address {
 					pk := secp256k1.GenPrivKey()
@@ -317,7 +317,7 @@ var _ = Describe("Multichain", func() {
 					Expect(err).NotTo(HaveOccurred())
 					var pk secp256k1.PrivKeySecp256k1
 					copy(pk[:], pkBytes)
-					addrEncoder := terra.NewAddressEncoder("terra")
+					addrEncoder := terra.NewAddressEncoder()
 					senderAddr, err := addrEncoder.EncodeAddress(multichain.RawAddress(pack.Bytes(pk.PubKey().Address())))
 					Expect(err).NotTo(HaveOccurred())
 					senderPrivKey := id.PrivKey{}
@@ -330,7 +330,7 @@ var _ = Describe("Multichain", func() {
 					Expect(err).NotTo(HaveOccurred())
 					var pk secp256k1.PrivKeySecp256k1
 					copy(pk[:], pkBytes)
-					addrEncoder := terra.NewAddressEncoder("terra")
+					addrEncoder := terra.NewAddressEncoder()
 					addr, err := addrEncoder.EncodeAddress(multichain.RawAddress(pack.Bytes(pk.PubKey().Address())))
 					Expect(err).NotTo(HaveOccurred())
 					return addr
@@ -338,7 +338,7 @@ var _ = Describe("Multichain", func() {
 				"http://127.0.0.1:26657",
 				func() multichain.Address {
 					recipientKey := secp256k1.GenPrivKey()
-					addrEncoder := terra.NewAddressEncoder("terra")
+					addrEncoder := terra.NewAddressEncoder()
 					recipient, err := addrEncoder.EncodeAddress(multichain.RawAddress(pack.Bytes(recipientKey.PubKey().Address())))
 					Expect(err).NotTo(HaveOccurred())
 					return recipient


### PR DESCRIPTION
There are several functions within the Cosmos SDK that make use of a global configuration to fetch the Bech32 prefix for an account. https://github.com/renproject/multichain/pull/49 updated the Multichain to set this prefix before each operation that interacts with the Cosmos SDK to allow us to support multiple Cosmos-compatible chains in the future. This has the obvious downside of potentially causing panics if the functions are called concurrently, and due to this we have decided to move away from this in favour of a config initialisation on boot. The downside to this is we cannot easily add support for other Cosmos-compatible chains in the near future because they will all use different prefixes. However, this issue is being tracked in the Cosmos SDK (https://github.com/cosmos/cosmos-sdk/issues/7448) and is aimed to be resolved before the next major release.