### PR TITLE
feat: client to expose latest block api

### DIFF
--- a/api/account/account.go
+++ b/api/account/account.go
@@ -62,6 +62,9 @@ type TxBuilder interface {
 // The Client interface defines the functionality required to interact with a
 // chain over RPC.
 type Client interface {
+	// LatestBlock returns the most recent block.
+	LatestBlock(context.Context) (pack.U64, error)
+
 	// AccountBalance returns the current balance of the given account.
 	AccountBalance(context.Context, address.Address) (pack.U256, error)
 

--- a/api/account/account.go
+++ b/api/account/account.go
@@ -62,7 +62,7 @@ type TxBuilder interface {
 // The Client interface defines the functionality required to interact with a
 // chain over RPC.
 type Client interface {
-	// LatestBlock returns the most recent block.
+	// LatestBlock returns the block number of the latest block.
 	LatestBlock(context.Context) (pack.U64, error)
 
 	// AccountBalance returns the current balance of the given account.

--- a/api/utxo/utxo.go
+++ b/api/utxo/utxo.go
@@ -80,6 +80,9 @@ type TxBuilder interface {
 // The Client interface defines the functionality required to interact with a
 // chain over RPC.
 type Client interface {
+	// LatestBlock returns the most recent block.
+	LatestBlock(context.Context) (pack.U64, error)
+
 	// Output returns the transaction output identified by the given outpoint.
 	// It also returns the number of confirmations for the output. If the output
 	// cannot be found before the context is done, or the output is invalid,

--- a/api/utxo/utxo.go
+++ b/api/utxo/utxo.go
@@ -80,7 +80,7 @@ type TxBuilder interface {
 // The Client interface defines the functionality required to interact with a
 // chain over RPC.
 type Client interface {
-	// LatestBlock returns the most recent block.
+	// LatestBlock returns the the height of the longest blockchain.
 	LatestBlock(context.Context) (pack.U64, error)
 
 	// Output returns the transaction output identified by the given outpoint.

--- a/chain/bitcoin/bitcoin.go
+++ b/chain/bitcoin/bitcoin.go
@@ -109,6 +109,16 @@ func NewClient(opts ClientOptions) Client {
 	}
 }
 
+// LatestBlock returns the most recent block.
+func (client *client) LatestBlock(ctx context.Context) (pack.U64, error) {
+	var resp int64
+	if err := client.send(ctx, &resp, "getblockcount"); err != nil {
+		return pack.NewU64(0), fmt.Errorf("get block count: %v", err)
+	}
+
+	return pack.NewU64(uint64(resp)), nil
+}
+
 // Output associated with an outpoint, and its number of confirmations.
 func (client *client) Output(ctx context.Context, outpoint utxo.Outpoint) (utxo.Output, pack.U64, error) {
 	resp := btcjson.TxRawResult{}

--- a/chain/bitcoin/bitcoin.go
+++ b/chain/bitcoin/bitcoin.go
@@ -115,6 +115,9 @@ func (client *client) LatestBlock(ctx context.Context) (pack.U64, error) {
 	if err := client.send(ctx, &resp, "getblockcount"); err != nil {
 		return pack.NewU64(0), fmt.Errorf("get block count: %v", err)
 	}
+	if resp < 0 {
+		return pack.NewU64(0), fmt.Errorf("unexpected block count, expected > 0, got: %v", resp)
+	}
 
 	return pack.NewU64(uint64(resp)), nil
 }

--- a/chain/bitcoin/bitcoin.go
+++ b/chain/bitcoin/bitcoin.go
@@ -109,7 +109,7 @@ func NewClient(opts ClientOptions) Client {
 	}
 }
 
-// LatestBlock returns the most recent block.
+// LatestBlock returns the height of the longest blockchain.
 func (client *client) LatestBlock(ctx context.Context) (pack.U64, error) {
 	var resp int64
 	if err := client.send(ctx, &resp, "getblockcount"); err != nil {

--- a/chain/cosmos/client.go
+++ b/chain/cosmos/client.go
@@ -134,6 +134,9 @@ func (client *Client) LatestBlock(ctx context.Context) (pack.U64, error) {
 	if err != nil {
 		return pack.NewU64(0), fmt.Errorf("get chain height: %v", err)
 	}
+	if height < 0 {
+		return pack.NewU64(0), fmt.Errorf("unexpected chain height, expected > 0, got: %v", height)
+	}
 
 	return pack.NewU64(uint64(height)), nil
 }

--- a/chain/cosmos/client.go
+++ b/chain/cosmos/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/renproject/pack"
 
 	cliContext "github.com/cosmos/cosmos-sdk/client/context"
+	cliRpc "github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
@@ -125,6 +126,16 @@ func NewClient(opts ClientOptions, cdc *codec.Codec, hrp string) *Client {
 		cdc:    cdc,
 		hrp:    hrp,
 	}
+}
+
+// LatestBlock returns the most recent block's number.
+func (client *Client) LatestBlock(ctx context.Context) (pack.U64, error) {
+	height, err := cliRpc.GetChainHeight(client.cliCtx)
+	if err != nil {
+		return pack.NewU64(0), fmt.Errorf("get chain height: %v", err)
+	}
+
+	return pack.NewU64(uint64(height)), nil
 }
 
 // Tx query transaction with txHash

--- a/chain/filecoin/client.go
+++ b/chain/filecoin/client.go
@@ -91,6 +91,9 @@ func (client *Client) LatestBlock(ctx context.Context) (pack.U64, error) {
 	if err != nil {
 		return pack.NewU64(0), fmt.Errorf("get chain head: %v", err)
 	}
+	if headTipset.Height() < 0 {
+		return pack.NewU64(0), fmt.Errorf("unexpected chain head, expected > 0, got: %v", headTipset.Height())
+	}
 
 	return pack.NewU64(uint64(headTipset.Height())), nil
 }

--- a/chain/filecoin/client.go
+++ b/chain/filecoin/client.go
@@ -85,7 +85,7 @@ func NewClient(opts ClientOptions) (*Client, error) {
 	return &Client{opts, node, closer}, nil
 }
 
-// LatestBlock returns the most recent block height.
+// LatestBlock returns the block number at the current chain head.
 func (client *Client) LatestBlock(ctx context.Context) (pack.U64, error) {
 	headTipset, err := client.node.ChainHead(ctx)
 	if err != nil {

--- a/infra/bitcoincash/Dockerfile
+++ b/infra/bitcoincash/Dockerfile
@@ -1,14 +1,16 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 # Install bitcoind-abc.
 RUN apt-get update && apt-get install --yes software-properties-common && \
-add-apt-repository --yes ppa:bitcoin-abc/ppa && apt-get update && \
+add-apt-repository ppa:ubuntu-toolchain-r/test && apt-get update && \
+apt-get install --yes g++-7 && \
+add-apt-repository ppa:bitcoin-cash-node/ppa && apt-get update && \
 apt-get install --yes bitcoind
 
 COPY bitcoin.conf /root/.bitcoin/
 COPY run.sh /root/
 RUN chmod +x /root/run.sh
 
-EXPOSE 18443
+EXPOSE 19443
 
 ENTRYPOINT ["./root/run.sh"]

--- a/multichain_test.go
+++ b/multichain_test.go
@@ -515,6 +515,15 @@ var _ = Describe("Multichain", func() {
 						time.Sleep(5 * time.Second)
 					}
 				})
+
+				It("should be able to fetch the latest block", func() {
+					// Initialise client
+					accountClient, _ := accountChain.initialise(accountChain.rpcURL)
+
+					latestBlock, err := accountClient.LatestBlock(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(uint64(latestBlock)).To(BeNumerically(">", 1))
+				})
 			})
 		}
 	})
@@ -975,6 +984,21 @@ var _ = Describe("Multichain", func() {
 						}
 						time.Sleep(10 * time.Second)
 					}
+				})
+
+				It("should be able to fetch the latest block", func() {
+					// get a random address
+					randAddr := make([]byte, 20)
+					rand.Read(randAddr)
+					pkhAddr, err := utxoChain.newAddressPKH(randAddr)
+					Expect(err).NotTo(HaveOccurred())
+
+					// initialise client
+					utxoClient, _, _ := utxoChain.initialise(utxoChain.rpcURL, pkhAddr)
+
+					latestBlock, err := utxoClient.LatestBlock(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(uint64(latestBlock)).To(BeNumerically(">", 1))
 				})
 			})
 		}


### PR DESCRIPTION
Adds the method:
```go
func (client *Client) LatestBlock(ctx context.Context) (pack.U64, error) 
```

to both the `utxo.Client` as well as `account.Client` interfaces. Tested for:
- [x] Bitcoin
- [x] Bitcoin Cash
- [x] Dogecoin
- [x] Zcash
- [x] Filecoin
- [x] Terra