### PR TITLE
Zcash AddressDecoder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Sleep until the nodes are up
         uses: jakejarvis/wait-action@master
         with:
-          time: '5m'
+          time: '8m'
 
       - name: Check on docker containers
         run: docker ps -a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Sleep until the nodes are up
         uses: jakejarvis/wait-action@master
         with:
-          time: '8m'
+          time: '10m'
 
       - name: Check on docker containers
         run: docker ps -a

--- a/chain/zcash/address.go
+++ b/chain/zcash/address.go
@@ -3,7 +3,6 @@ package zcash
 import (
 	"bytes"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -55,79 +54,77 @@ func NewAddressEncodeDecoder(params *Params) AddressEncodeDecoder {
 
 // EncodeAddress implements the address.Encoder interface
 func (encoder AddressEncoder) EncodeAddress(rawAddr address.RawAddress) (address.Address, error) {
-	if len(rawAddr) != 26 && len(rawAddr) != 25 {
-		return address.Address(""), fmt.Errorf("address of unknown length")
-	}
-
 	var addrType uint8
 	var err error
 	var hash [20]byte
 	var prefix []byte
-	if len(rawAddr) == 26 {
-		prefix = rawAddr[:2]
-		addrType, err = addressType(prefix, encoder.params)
-		copy(hash[:], rawAddr[2:22])
-	} else {
+
+	switch len(rawAddr) {
+	case ripemd160.Size + 5:
 		prefix = rawAddr[:1]
 		addrType, err = addressType(prefix, encoder.params)
 		copy(hash[:], rawAddr[1:21])
+	case ripemd160.Size + 6:
+		prefix = rawAddr[:2]
+		addrType, err = addressType(prefix, encoder.params)
+		copy(hash[:], rawAddr[2:22])
+	default:
+		return address.Address(""), fmt.Errorf("validating address length: expected %v or %v, got %v", ripemd160.Size+5, ripemd160.Size+6, len(rawAddr))
 	}
+
 	if err != nil {
-		return address.Address(""), fmt.Errorf("parsing prefix: %v", err)
+		return address.Address(""), fmt.Errorf("parsing address type: %v", err)
 	}
 
 	switch addrType {
 	case 0, 1: // P2PKH or P2SH
 		return address.Address(pack.String(encodeAddress(hash[:], prefix))), nil
 	default:
-		return address.Address(""), errors.New("unknown address")
+		return address.Address(""), fmt.Errorf("unexpected address type: %v", addrType)
 	}
 }
 
 // DecodeAddress implements the address.Decoder interface
 func (decoder AddressDecoder) DecodeAddress(addr address.Address) (address.RawAddress, error) {
 	var decoded = base58.Decode(string(addr))
-	if len(decoded) != 26 && len(decoded) != 25 {
-		return nil, base58.ErrInvalidFormat
+	var addrType uint8
+	var err error
+	var hash [20]byte
+
+	switch len(decoded) {
+	case ripemd160.Size + 5:
+		addrType, err = addressType(decoded[:1], decoder.params)
+		copy(hash[:], decoded[1:21])
+	case ripemd160.Size + 6:
+		addrType, err = addressType(decoded[:2], decoder.params)
+		copy(hash[:], decoded[2:22])
+	default:
+		return nil, fmt.Errorf("validating address length: expected %v or %v, got %v", ripemd160.Size+5, ripemd160.Size+6, len(decoded))
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("parsing address type: %v", err)
 	}
 
 	var cksum [4]byte
 	copy(cksum[:], decoded[len(decoded)-4:])
 	if checksum(decoded[:len(decoded)-4]) != cksum {
-		return nil, base58.ErrChecksum
-	}
-
-	if len(decoded)-6 != ripemd160.Size && len(decoded)-5 != ripemd160.Size {
-		return nil, errors.New("incorrect payload len")
-	}
-
-	var addrType uint8
-	var err error
-	var hash [20]byte
-	if len(decoded) == 26 {
-		addrType, err = addressType(decoded[:2], decoder.params)
-		copy(hash[:], decoded[2:22])
-	} else {
-		addrType, err = addressType(decoded[:1], decoder.params)
-		copy(hash[:], decoded[1:21])
-	}
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validating checksum: %v", base58.ErrChecksum)
 	}
 
 	switch addrType {
 	case 0, 1: // P2PKH or P2SH
 		return address.RawAddress(pack.Bytes(decoded)), nil
 	default:
-		return nil, errors.New("unknown address")
+		return nil, fmt.Errorf("unexpected address type: %v", addrType)
 	}
 }
 
-func addressType(prefix []byte, param *Params) (uint8, error) {
-	if bytes.Equal(prefix, param.P2PKHPrefix) {
+func addressType(prefix []byte, params *Params) (uint8, error) {
+	if bytes.Equal(prefix, params.P2PKHPrefix) {
 		return 0, nil
 	}
-	if bytes.Equal(prefix, param.P2SHPrefix) {
+	if bytes.Equal(prefix, params.P2SHPrefix) {
 		return 1, nil
 	}
 	return 0, btcutil.ErrUnknownAddressType
@@ -246,20 +243,24 @@ func (addr AddressScriptHash) IsForNet(params *chaincfg.Params) bool {
 
 // addressFromRawBytes decodes a string-representation of an address to an address
 // type that implements the zcash.Address interface
-func addressFromRawBytes(addrBytes []byte) (Address, error) {
+func addressFromRawBytes(addrBytes []byte, params *Params) (Address, error) {
 	var addrType uint8
-	var params *Params
 	var err error
 	var hash [20]byte
-	if len(addrBytes) == 26 {
-		addrType, params, err = parsePrefix(addrBytes[:2])
-		copy(hash[:], addrBytes[2:22])
-	} else {
-		addrType, params, err = parsePrefix(addrBytes[:1])
+
+	switch len(addrBytes) {
+	case ripemd160.Size + 5:
+		addrType, err = addressType(addrBytes[:1], params)
 		copy(hash[:], addrBytes[1:21])
+	case ripemd160.Size + 6:
+		addrType, err = addressType(addrBytes[:2], params)
+		copy(hash[:], addrBytes[2:22])
+	default:
+		return nil, fmt.Errorf("validating address length: expected %v or %v, got %v", ripemd160.Size+5, ripemd160.Size+6, len(addrBytes))
 	}
+
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing address type: %v", err)
 	}
 
 	switch addrType {
@@ -267,9 +268,9 @@ func addressFromRawBytes(addrBytes []byte) (Address, error) {
 		return NewAddressPubKeyHash(hash[:], params)
 	case 1: // P2SH
 		return NewAddressScriptHashFromHash(hash[:], params)
+	default:
+		return nil, fmt.Errorf("unexpected address type: %v", addrType)
 	}
-
-	return nil, errors.New("unknown address")
 }
 
 func encodeAddress(hash, prefix []byte) string {
@@ -289,26 +290,4 @@ func checksum(input []byte) (cksum [4]byte) {
 	)
 	copy(cksum[:], h2[:4])
 	return
-}
-
-func parsePrefix(prefix []byte) (uint8, *Params, error) {
-	if bytes.Equal(prefix, MainNetParams.P2PKHPrefix) {
-		return 0, &MainNetParams, nil
-	}
-	if bytes.Equal(prefix, MainNetParams.P2SHPrefix) {
-		return 1, &MainNetParams, nil
-	}
-	if bytes.Equal(prefix, TestNet3Params.P2PKHPrefix) {
-		return 0, &TestNet3Params, nil
-	}
-	if bytes.Equal(prefix, TestNet3Params.P2SHPrefix) {
-		return 1, &TestNet3Params, nil
-	}
-	if bytes.Equal(prefix, RegressionNetParams.P2PKHPrefix) {
-		return 0, &RegressionNetParams, nil
-	}
-	if bytes.Equal(prefix, RegressionNetParams.P2SHPrefix) {
-		return 1, &RegressionNetParams, nil
-	}
-	return 0, nil, btcutil.ErrUnknownAddressType
 }

--- a/chain/zcash/address.go
+++ b/chain/zcash/address.go
@@ -65,11 +65,11 @@ func (encoder AddressEncoder) EncodeAddress(rawAddr address.RawAddress) (address
 	var prefix []byte
 	if len(rawAddr) == 26 {
 		prefix = rawAddr[:2]
-		addrType, _, err = parsePrefix(prefix)
+		addrType, err = addressType(prefix, encoder.params)
 		copy(hash[:], rawAddr[2:22])
 	} else {
 		prefix = rawAddr[:1]
-		addrType, _, err = parsePrefix(prefix)
+		addrType, err = addressType(prefix, encoder.params)
 		copy(hash[:], rawAddr[1:21])
 	}
 	if err != nil {
@@ -105,10 +105,10 @@ func (decoder AddressDecoder) DecodeAddress(addr address.Address) (address.RawAd
 	var err error
 	var hash [20]byte
 	if len(decoded) == 26 {
-		addrType, _, err = parsePrefix(decoded[:2])
+		addrType, err = addressType(decoded[:2], decoder.params)
 		copy(hash[:], decoded[2:22])
 	} else {
-		addrType, _, err = parsePrefix(decoded[:1])
+		addrType, err = addressType(decoded[:1], decoder.params)
 		copy(hash[:], decoded[1:21])
 	}
 	if err != nil {
@@ -121,6 +121,16 @@ func (decoder AddressDecoder) DecodeAddress(addr address.Address) (address.RawAd
 	default:
 		return nil, errors.New("unknown address")
 	}
+}
+
+func addressType(prefix []byte, param *Params) (uint8, error) {
+	if bytes.Equal(prefix, param.P2PKHPrefix) {
+		return 0, nil
+	}
+	if bytes.Equal(prefix, param.P2SHPrefix) {
+		return 1, nil
+	}
+	return 0, btcutil.ErrUnknownAddressType
 }
 
 // An Address represents a Zcash address.

--- a/chain/zcash/address_test.go
+++ b/chain/zcash/address_test.go
@@ -1,6 +1,7 @@
 package zcash_test
 
 import (
+	"bytes"
 	"math/rand"
 
 	. "github.com/onsi/ginkgo"
@@ -52,7 +53,7 @@ var _ = Describe("Zcash Address", func() {
 			params := []zcash.Params{
 				zcash.MainNetParams,
 				zcash.TestNet3Params,
-				// zcash.RegressionNetParams,   // disable Regression net as it has same prefix as testnet
+				zcash.RegressionNetParams,
 			}
 
 			for i, param := range params {
@@ -75,15 +76,16 @@ var _ = Describe("Zcash Address", func() {
 				for j := range params {
 					addrEncodeDecoder := zcash.NewAddressEncodeDecoder(&params[j])
 					_, err := addrEncodeDecoder.DecodeAddress(p2pkhAddr)
-					// Only the decoder has the same network param should work
-					if i == j {
+					// Check the prefix in the params instead of comparing the network directly
+					// because testnet and regression network has the same prefix.
+					if bytes.Equal(params[i].P2PKHPrefix, params[j].P2PKHPrefix) {
 						Expect(err).NotTo(HaveOccurred())
 					} else {
 						Expect(err).To(HaveOccurred())
 					}
 
 					_, err = addrEncodeDecoder.DecodeAddress(p2shAddr)
-					if i == j {
+					if bytes.Equal(params[i].P2PKHPrefix, params[j].P2PKHPrefix) {
 						Expect(err).NotTo(HaveOccurred())
 					} else {
 						Expect(err).To(HaveOccurred())

--- a/chain/zcash/address_test.go
+++ b/chain/zcash/address_test.go
@@ -3,10 +3,11 @@ package zcash_test
 import (
 	"math/rand"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcutil"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcutil"
 	"github.com/renproject/id"
 	"github.com/renproject/multichain/api/address"
 	"github.com/renproject/multichain/chain/zcash"
@@ -43,6 +44,52 @@ var _ = Describe("Zcash Address", func() {
 			encodedAddr, err := addrEncodeDecoder.EncodeAddress(decodedRawAddr)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(encodedAddr).To(Equal(addr))
+		})
+	})
+
+	Context("AddressEncodeDecoder", func() {
+		It("should give an error when decoding address on different network", func() {
+			params := []zcash.Params{
+				zcash.MainNetParams,
+				zcash.TestNet3Params,
+				// zcash.RegressionNetParams,   // disable Regression net as it has same prefix as testnet
+			}
+
+			for i, param := range params {
+				// Generate a P2PKH address with the params
+				pk := id.NewPrivKey()
+				wif, err := btcutil.NewWIF((*btcec.PrivateKey)(pk), param.Params, true)
+				Expect(err).NotTo(HaveOccurred())
+				addrPubKeyHash, err := zcash.NewAddressPubKeyHash(btcutil.Hash160(wif.PrivKey.PubKey().SerializeUncompressed()), &param)
+				Expect(err).NotTo(HaveOccurred())
+				p2pkhAddr := address.Address(addrPubKeyHash.EncodeAddress())
+
+				// Generate a P2SH address with the params
+				script := make([]byte, rand.Intn(100))
+				rand.Read(script)
+				addrScriptHash, err := zcash.NewAddressScriptHash(script, &param)
+				Expect(err).NotTo(HaveOccurred())
+				p2shAddr := address.Address(addrScriptHash.EncodeAddress())
+
+				// Try decode the address using decoders with different network params
+				for j := range params {
+					addrEncodeDecoder := zcash.NewAddressEncodeDecoder(&params[j])
+					_, err := addrEncodeDecoder.DecodeAddress(p2pkhAddr)
+					// Only the decoder has the same network param should work
+					if i == j {
+						Expect(err).NotTo(HaveOccurred())
+					} else {
+						Expect(err).To(HaveOccurred())
+					}
+
+					_, err = addrEncodeDecoder.DecodeAddress(p2shAddr)
+					if i == j {
+						Expect(err).NotTo(HaveOccurred())
+					} else {
+						Expect(err).To(HaveOccurred())
+					}
+				}
+			}
 		})
 	})
 })

--- a/chain/zcash/utxo.go
+++ b/chain/zcash/utxo.go
@@ -85,7 +85,7 @@ func (txBuilder TxBuilder) BuildTx(inputs []utxo.Input, recipients []utxo.Recipi
 		if err != nil {
 			return &Tx{}, err
 		}
-		addr, err := addressFromRawBytes(addrBytes)
+		addr, err := addressFromRawBytes(addrBytes, txBuilder.params)
 		if err != nil {
 			return &Tx{}, err
 		}


### PR DESCRIPTION
Currently the `AddressEncodeDecoder` for zcash will not return an error when trying to decode an address on different network, for example:
```golang
addrEncodeDecoder := zcash.NewAddressEncodeDecoder(&zcash.MainNetParams)
addr := multichain.Address("t28Tc2BUTHifXthexsohy89umGdqMWLSUqw") // Testnet address 
_, err := addrEncodeDecoder.DecodeAddress(addr)
Expect(err).To(HaveOccurred())
```
I expect this to return an error when trying to decode a testnet address using a mainnet `AddressEncodeDecoder`.
All other bitcoin-like chains are working fine and I expect zcash to have the same behaviour.  

The `param` we passed to initialize the `AddressEncodeDecoder` is not used when encoding/decoding.  And the 
 `parsePrefix` function checks all possible networks. I changed that to compare only with the param of the `AddressEncodeDecoder`. 

