### PR TITLE
fix: prefix byte for script hash address

### DIFF
--- a/chain/digibyte/digibyte.go
+++ b/chain/digibyte/digibyte.go
@@ -132,7 +132,7 @@ var MainNetParams = chaincfg.Params{
 
 	// Address encoding magics
 	PubKeyHashAddrID:        0x1e, // starts with 1
-	ScriptHashAddrID:        0x32, // starts with 3
+	ScriptHashAddrID:        0x3f, // starts with 3
 	PrivateKeyID:            0x80, // starts with 5 (uncompressed) or K (compressed)
 	WitnessPubKeyHashAddrID: 0x06, // starts with p2
 	WitnessScriptHashAddrID: 0x0A, // starts with 7Xh


### PR DESCRIPTION
This PR fixes the prefix byte for DigiByte Script Hash Address
1. [DigiByte params](https://github.com/DigiByte-Core/digibyte/blob/82414be2e78bd136daeb91f55c72768a9b700957/src/chainparams.cpp#L233)

A follow up PR will be required to also handle the "Old Prefix" for Script Hash Address.