### PR TITLE
fix: add missing declarations for Solana

### DIFF
--- a/multichain.go
+++ b/multichain.go
@@ -254,7 +254,7 @@ func (chain Chain) ChainType() ChainType {
 	switch chain {
 	case Bitcoin, BitcoinCash, DigiByte, Dogecoin, Zcash:
 		return ChainTypeUTXOBased
-	case BinanceSmartChain, Ethereum, Filecoin, Terra:
+	case BinanceSmartChain, Ethereum, Filecoin, Solana, Terra:
 		return ChainTypeAccountBased
 
 	// These chains are handled separately because they are mock chains. These
@@ -300,6 +300,8 @@ func (chain Chain) NativeAsset() Asset {
 		return ETH
 	case Filecoin:
 		return FIL
+	case Solana:
+		return SOL
 	case Terra:
 		return LUNA
 	case Zcash:

--- a/multichain_test.go
+++ b/multichain_test.go
@@ -74,6 +74,70 @@ var _ = Describe("Multichain", func() {
 	testFlags[multichain.Terra] = *testLUNA
 	testFlags[multichain.Zcash] = *testZEC
 
+	Context("Multichain Declarations", func() {
+		Context("All supporting chains/assets are declared", func() {
+			accountChains := []struct {
+				chain multichain.Chain
+				asset multichain.Asset
+			}{
+				{
+					multichain.Filecoin,
+					multichain.FIL,
+				},
+				{
+					multichain.Solana,
+					multichain.SOL,
+				},
+				{
+					multichain.Terra,
+					multichain.LUNA,
+				},
+			}
+			utxoChains := []struct {
+				chain multichain.Chain
+				asset multichain.Asset
+			}{
+				{
+					multichain.Bitcoin,
+					multichain.BTC,
+				},
+				{
+					multichain.BitcoinCash,
+					multichain.BCH,
+				},
+				{
+					multichain.DigiByte,
+					multichain.DGB,
+				},
+				{
+					multichain.Dogecoin,
+					multichain.DOGE,
+				},
+				{
+					multichain.Zcash,
+					multichain.ZEC,
+				},
+			}
+
+			for _, accountChain := range accountChains {
+				accountChain := accountChain
+				Specify(fmt.Sprintf("Chain=%v, Asset=%v should be supported", accountChain.chain, accountChain.asset), func() {
+					Expect(accountChain.chain.IsAccountBased()).To(BeTrue())
+					Expect(accountChain.chain.NativeAsset()).To(Equal(accountChain.asset))
+					Expect(accountChain.asset.OriginChain()).To(Equal(accountChain.chain))
+				})
+			}
+			for _, utxoChain := range utxoChains {
+				utxoChain := utxoChain
+				Specify(fmt.Sprintf("Chain=%v, Asset=%v should be supported", utxoChain.chain, utxoChain.asset), func() {
+					Expect(utxoChain.chain.IsUTXOBased()).To(BeTrue())
+					Expect(utxoChain.chain.NativeAsset()).To(Equal(utxoChain.asset))
+					Expect(utxoChain.asset.OriginChain()).To(Equal(utxoChain.chain))
+				})
+			}
+		})
+	})
+
 	//
 	// ADDRESS API
 	//


### PR DESCRIPTION
This PR adds missing declarations, namely, `NativeAsset` and `ChainType` for Solana.