### PR TITLE
bump up solana-ffi version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/renproject/id v0.4.2
 	github.com/renproject/pack v0.2.5
-	github.com/renproject/solana-ffi v0.1.0
+	github.com/renproject/solana-ffi v0.1.1
 	github.com/renproject/surge v1.2.6
 	github.com/tendermint/tendermint v0.33.8
 	github.com/terra-project/core v0.4.0-rc.4


### PR DESCRIPTION
Due to different toolchains (in `filecoin-ffi` and `solana-ffi`) and link time optimisation enabled by default for staticlibs, duplicate symbols were found from both `libfilcrypto.a` and `libsolana_ffi.a`.

The bumped up version of `solana-ffi` resolves this.