### PR TITLE
fix: cosmos addrs are expected to be 20-bytes long

### DIFF
--- a/chain/cosmos/address.go
+++ b/chain/cosmos/address.go
@@ -1,6 +1,8 @@
 package cosmos
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/renproject/multichain/api/address"
 )
@@ -60,12 +62,18 @@ func (decoder AddressDecoder) DecodeAddress(addr address.Address) (address.RawAd
 	if err != nil {
 		return nil, err
 	}
+	if len(rawAddr) != sdk.AddrLen {
+		return nil, fmt.Errorf("unexpected address length: want=%v, got=%v", sdk.AddrLen, len(rawAddr))
+	}
 	return address.RawAddress(rawAddr), nil
 }
 
 // EncodeAddress consumes raw bytes and encodes them to a human-readable
 // address format.
 func (encoder AddressEncoder) EncodeAddress(rawAddr address.RawAddress) (address.Address, error) {
+	if len(rawAddr) != sdk.AddrLen {
+		return address.Address(""), fmt.Errorf("unexpected address length: want=%v, got=%v", sdk.AddrLen, len(rawAddr))
+	}
 	bech32Addr := sdk.AccAddress(rawAddr)
 	return address.Address(bech32Addr.String()), nil
 }

--- a/chain/terra/address_test.go
+++ b/chain/terra/address_test.go
@@ -13,16 +13,32 @@ import (
 
 var _ = Describe("Terra", func() {
 	Context("when decoding address", func() {
-		Context("when decoding Terra address", func() {
+		decoder := terra.NewAddressDecoder()
+		Context("when decoding a valid address", func() {
 			It("should work", func() {
-				decoder := terra.NewAddressDecoder()
-
 				addrStr := "terra1ztez03dp94y2x55fkhmrvj37ck204geq33msma"
 				_, err := decoder.DecodeAddress(multichain.Address(pack.NewString(addrStr)))
 				Expect(err).ToNot(HaveOccurred())
-
-				addrStr = ""
-				_, err = decoder.DecodeAddress(multichain.Address(pack.NewString(addrStr)))
+			})
+		})
+		Context("when decoding an address with invalid prefix", func() {
+			It("should fail", func() {
+				addrStr := "cosmosztez03dp94y2x55fkhmrvj37ck204geq33msma"
+				_, err := decoder.DecodeAddress(multichain.Address(pack.NewString(addrStr)))
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("when decoding an invalid address", func() {
+			It("should fail", func() {
+				addrStr := "terra1ztez03dp94y2x55fkhmrvj37ck204geq33msm"
+				_, err := decoder.DecodeAddress(multichain.Address(pack.NewString(addrStr)))
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("when decoding an empty address", func() {
+			It("should fail", func() {
+				addrStr := ""
+				_, err := decoder.DecodeAddress(multichain.Address(pack.NewString(addrStr)))
 				Expect(err).Should(MatchError(fmt.Errorf("unexpected address length: want=20, got=0")))
 			})
 		})

--- a/chain/terra/address_test.go
+++ b/chain/terra/address_test.go
@@ -1,6 +1,8 @@
 package terra_test
 
 import (
+	"fmt"
+
 	"github.com/renproject/multichain"
 	"github.com/renproject/multichain/chain/terra"
 	"github.com/renproject/pack"
@@ -18,6 +20,10 @@ var _ = Describe("Terra", func() {
 				addrStr := "terra1ztez03dp94y2x55fkhmrvj37ck204geq33msma"
 				_, err := decoder.DecodeAddress(multichain.Address(pack.NewString(addrStr)))
 				Expect(err).ToNot(HaveOccurred())
+
+				addrStr = ""
+				_, err = decoder.DecodeAddress(multichain.Address(pack.NewString(addrStr)))
+				Expect(err).Should(MatchError(fmt.Errorf("unexpected address length: want=20, got=0")))
 			})
 		})
 	})


### PR DESCRIPTION
So far we were only relying on the `cosmos-sdk/types` package to catch any possible address-related errors (format, checksum, etc.). But an empty string `multichain.Address("")` passed the decoder giving us no error yet an invalid raw address.

We now explicitly ensure that raw addresses are `AddrLen` long when decoding/encoding.