### PR TITLE
Update base image for bitcoin local infra

### DIFF
--- a/infra/bitcoin/Dockerfile
+++ b/infra/bitcoin/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install --yes software-properties-common
 RUN apt-get install --yes curl


### PR DESCRIPTION
I'm getting an error when compiling the bitcoin local image with `ubuntu:xenial`
```
Step 3/12 : RUN apt-get install --yes curl
 ---> Running in 650c4a06bf08
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  curl
0 upgraded, 1 newly installed, 0 to remove and 10 not upgraded.
Need to get 139 kB of archives.
After this operation, 340 kB of additional disk space will be used.
Err:1 http://security.ubuntu.com/ubuntu xenial-security/main amd64 curl amd64 7.47.0-1ubuntu2.16
  404  Not Found [IP: 91.189.88.152 80]
Err:1 http://security.ubuntu.com/ubuntu xenial-security/main amd64 curl amd64 7.47.0-1ubuntu2.16
  404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/curl_7.47.0-1ubuntu2.16_amd64.deb  404  Not Found [IP: 91.189.88.152 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
ERROR: Service 'bitcoin' failed to build : The command '/bin/sh -c apt-get install --yes curl' returned a non-zero code: 100
```
My docker engine version is v20.10.2.
Either adding `--fix-missing` or changing to `ubuntu:bionic` fix the problem for me. 