### PR TITLE
feat: fetch and deserialize gateway registry account data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
             git clone https://github.com/renproject/ren-solana.git
             cd ren-solana
             echo ${{ secrets.GATEWAY_PROGRAM_ID }} > ~/.config/solana/gateway-program.json
+            echo ${{ secrets.GATEWAY_REGISTRY_PROGRAM_ID }} > ~/.config/solana/gateway-registry-program.json
             ./setup.sh
 
       - name: Sleep until the node is up
@@ -80,6 +81,23 @@ jobs:
               --keypair ~/.config/solana/id.json \
               --program-id ~/.config/solana/gateway-program.json \
               target/deploy/gateway.so
+            solana program deploy --final \
+              --keypair ~/.config/solana/id.json \
+              --program-id ~/.config/solana/gateway-registry-program.json \
+              target/deploy/gateway_registry.so
+            target/debug/gateway-registry initialize \
+              --owner ~/.config/solana/id.json \
+              --fee-payer ~/.config/solana/id.json
+            target/debug/gateway-registry update \
+              --owner ~/.config/solana/id.json \
+              --fee-payer ~/.config/solana/id.json \
+              --selector "BTC/toSolana" \
+              --gateway "9TaQuUfNMC5rFvdtzhHPk84WaFH3SFnweZn4tw9RriDP"
+            target/debug/gateway-registry update \
+              --owner ~/.config/solana/id.json \
+              --fee-payer ~/.config/solana/id.json \
+              --selector "ZEC/toSolana" \
+              --gateway "9rCXCJDsnS53QtdXvYhYCAxb6yBE16KAQx5zHWfHe9QF"
             cd $GITHUB_WORKSPACE/chain/solana
             go test -timeout 100s
 

--- a/chain/solana/solana_test.go
+++ b/chain/solana/solana_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Solana", func() {
 		})
 	})
 
-	FContext("When getting Gateways from Registry", func() {
+	Context("When getting Gateways from Registry", func() {
 		It("should deserialize successfully", func() {
 			// Solana client using default client options.
 			client := solana.NewClient(solana.DefaultClientOptions())

--- a/chain/solana/solanarpc.go
+++ b/chain/solana/solanarpc.go
@@ -28,3 +28,13 @@ type BurnLog struct {
 	Amount    int      `json:"amount"`
 	Recipient [25]byte `json:"recipient"`
 }
+
+type Bytes32 = [32]byte
+
+type gatewayRegistry struct {
+	IsInitialised bool
+	Owner         Bytes32
+	Count         uint64
+	Selectors     []Bytes32
+	Gateways      []Bytes32
+}

--- a/chain/solana/solanarpc.go
+++ b/chain/solana/solanarpc.go
@@ -8,11 +8,11 @@ type AccountContext struct {
 
 // AccountValue is the JSON-interface of the account's information.
 type AccountValue struct {
-	Data       string `json:"data"`
-	Executable bool   `json:"executable"`
-	Lamports   int    `json:"lamports"`
-	Owner      string `json:"owner"`
-	RentEpoch  int    `json:"rentEpoch"`
+	Data       [2]string `json:"data"`
+	Executable bool      `json:"executable"`
+	Lamports   int       `json:"lamports"`
+	Owner      string    `json:"owner"`
+	RentEpoch  int       `json:"rentEpoch"`
 }
 
 // ResponseGetAccountInfo is the JSON-interface of the response for the
@@ -29,10 +29,13 @@ type BurnLog struct {
 	Recipient [25]byte `json:"recipient"`
 }
 
+// Bytes32 is an alias for [32]byte
 type Bytes32 = [32]byte
 
-type gatewayRegistry struct {
-	IsInitialised bool
+// GatewayRegistry defines the state of gateway registry, serialized and
+// deserialized by the borsh schema.
+type GatewayRegistry struct {
+	IsInitialised uint8
 	Owner         Bytes32
 	Count         uint64
 	Selectors     []Bytes32

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/ipfs/go-cid v0.0.7
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/multiformats/go-varint v0.0.6
+	github.com/near/borsh-go v0.3.0
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/renproject/id v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -1225,6 +1225,8 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/near/borsh-go v0.3.0 h1:+DvG7eApOD3KrHIh7TwZvYzhXUF/OzMTC6aRTUEtW+8=
+github.com/near/borsh-go v0.3.0/go.mod h1:NeMochZp7jN/pYFuxLkrZtmLqbADmnp/y1+/dL+AsyQ=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/nikkolasg/hexjson v0.0.0-20181101101858-78e39397e00c/go.mod h1:7qN3Y0BvzRUf4LofcoJplQL10lsFDb4PYlePTVwrP28=


### PR DESCRIPTION
This PR implements APIs to get gateway addresses from Ren's [Gateway Registry](https://github.com/renproject/ren-solana/pull/4) on Solana
- [x] Implement
- [x] Test