### PR TITLE
refactor: application specific structs moved out of multichain

### DIFF
--- a/chain/solana/solana_test.go
+++ b/chain/solana/solana_test.go
@@ -22,6 +22,19 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// Bytes32 is an alias for [32]byte
+type Bytes32 = [32]byte
+
+// GatewayRegistry defines the state of gateway registry, serialized and
+// deserialized by the borsh schema.
+type GatewayRegistry struct {
+	IsInitialised uint8
+	Owner         Bytes32
+	Count         uint64
+	Selectors     []Bytes32
+	Gateways      []Bytes32
+}
+
 var _ = Describe("Solana", func() {
 	// Setup logger.
 	loggerConfig := zap.NewDevelopmentConfig()
@@ -104,7 +117,7 @@ var _ = Describe("Solana", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Deserialize the account data into registry state's structure.
-			registry := solana.GatewayRegistry{}
+			registry := GatewayRegistry{}
 			err = borsh.Deserialize(&registry, []byte(accountData))
 			Expect(err).NotTo(HaveOccurred())
 

--- a/chain/solana/solanarpc.go
+++ b/chain/solana/solanarpc.go
@@ -21,23 +21,3 @@ type ResponseGetAccountInfo struct {
 	Context AccountContext `json:"context"`
 	Value   AccountValue   `json:"value"`
 }
-
-// BurnLog is the data stored in a burn log account, that is received in its
-// Base58 encoded format as a part of the getAccountInfo response.
-type BurnLog struct {
-	Amount    int      `json:"amount"`
-	Recipient [25]byte `json:"recipient"`
-}
-
-// Bytes32 is an alias for [32]byte
-type Bytes32 = [32]byte
-
-// GatewayRegistry defines the state of gateway registry, serialized and
-// deserialized by the borsh schema.
-type GatewayRegistry struct {
-	IsInitialised uint8
-	Owner         Bytes32
-	Count         uint64
-	Selectors     []Bytes32
-	Gateways      []Bytes32
-}


### PR DESCRIPTION
This PR removes application specific structs that were in Multichain's solana package. Instead they will be moved to Darknode.