### PR TITLE
solana infra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,14 +92,11 @@ jobs:
 
       - name: Setup environment for Solana tests
         run: |
-            sh -c "$(curl -sSfL https://release.solana.com/v1.5.13/install)"
+            sh -c "$(curl -sSfL https://release.solana.com/v1.6.8/install)"
             cd $GITHUB_WORKSPACE
             export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
-            git clone https://github.com/renproject/ren-solana.git
-            cd ren-solana
-            echo ${{ secrets.GATEWAY_PROGRAM_ID }} > ~/.config/solana/gateway-program.json
-            echo ${{ secrets.GATEWAY_REGISTRY_PROGRAM_ID }} > ~/.config/solana/gateway-registry-program.json
-            ./setup.sh
+            echo ${{ secrets.SOLANA_KEY }} > ~/.config/solana/id.json
+            docker run -d -h 0.0.0.0 -p 8899:8899 -p 8900:8900 renbot/ren-solana:latest
 
       - name: Sleep until the node is up
         uses: jakejarvis/wait-action@master
@@ -112,29 +109,6 @@ jobs:
       - name: Run tests for Solana
         run: |
             export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
-            cd $GITHUB_WORKSPACE/ren-solana
-            solana airdrop --url http://0.0.0.0:8899 10
-            solana program deploy --final \
-              --keypair ~/.config/solana/id.json \
-              --program-id ~/.config/solana/gateway-program.json \
-              target/deploy/gateway.so
-            solana program deploy --final \
-              --keypair ~/.config/solana/id.json \
-              --program-id ~/.config/solana/gateway-registry-program.json \
-              target/deploy/gateway_registry.so
-            target/debug/gateway-registry initialize \
-              --owner ~/.config/solana/id.json \
-              --fee-payer ~/.config/solana/id.json
-            target/debug/gateway-registry update \
-              --owner ~/.config/solana/id.json \
-              --fee-payer ~/.config/solana/id.json \
-              --selector "BTC/toSolana" \
-              --gateway "FDdKRjbBeFtyu5c66cZghJsTTjDTT1aD3zsgTWMTpaif"
-            target/debug/gateway-registry update \
-              --owner ~/.config/solana/id.json \
-              --fee-payer ~/.config/solana/id.json \
-              --selector "ZEC/toSolana" \
-              --gateway "9rCXCJDsnS53QtdXvYhYCAxb6yBE16KAQx5zHWfHe9QF"
             cd $GITHUB_WORKSPACE/chain/solana
             go test -timeout 100s
 

--- a/chain/solana/solana.go
+++ b/chain/solana/solana.go
@@ -65,7 +65,7 @@ func FindProgramAddress(seeds []byte, program address.RawAddress) (address.Addre
 	return ProgramDerivedAddress(seeds, encoded), nil
 }
 
-// GetAccountInfo fetches and returns the account data.
+// GetAccountData fetches and returns the account data.
 func (client *Client) GetAccountData(account address.Address) (pack.Bytes, error) {
 	// Fetch account info with base64 encoding. The default base58 encoding does
 	// not support account data that is larger than 128 bytes, hence base64.

--- a/chain/solana/solana_test.go
+++ b/chain/solana/solana_test.go
@@ -3,7 +3,6 @@ package solana_test
 import (
 	"context"
 	"encoding/binary"
-	"encoding/hex"
 	"os"
 	"time"
 
@@ -52,21 +51,9 @@ var _ = Describe("Solana", func() {
 			Expect(err).NotTo(HaveOccurred())
 			keypairPath := userHomeDir + "/.config/solana/id.json"
 
-			// RenVM secret and corresponding authority (20-byte Ethereum address).
+			// RenVM secret and the selector for this gateway.
 			renVmSecret := "0000000000000000000000000000000000000000000000000000000000000001"
-			renVmAuthority := "7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
-			renVmAuthorityBytes, err := hex.DecodeString(renVmAuthority)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Initialize Gateway for the RenBTC token.
 			selector := "BTC/toSolana"
-			initializeSig := cgo.GatewayInitialize(keypairPath, solana.DefaultClientRPCURL, renVmAuthorityBytes, selector)
-			logger.Debug("Initialize", zap.String("tx signature", string(initializeSig)))
-
-			// Initialize a new token account.
-			time.Sleep(10 * time.Second)
-			initializeAccountSig := cgo.GatewayInitializeAccount(keypairPath, solana.DefaultClientRPCURL, selector)
-			logger.Debug("InitializeAccount", zap.String("tx signature", string(initializeAccountSig)))
 
 			// Mint some tokens.
 			time.Sleep(10 * time.Second)

--- a/chain/solana/solana_test.go
+++ b/chain/solana/solana_test.go
@@ -122,25 +122,20 @@ var _ = Describe("Solana", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// The registry (in the CI test environment) is pre-populated with gateway
-			// addresses for BTC/toSolana and ZEC/toSolana selectors.
+			// addresses for BTC/toSolana selector.
 			btcSelectorHash := [32]byte{}
 			copy(btcSelectorHash[:], crypto.Keccak256([]byte("BTC/toSolana")))
-			zecSelectorHash := [32]byte{}
-			copy(zecSelectorHash[:], crypto.Keccak256([]byte("ZEC/toSolana")))
 			zero := pack.NewU256FromU8(pack.U8(0)).Bytes32()
 
 			addrEncodeDecoder := solana.NewAddressEncodeDecoder()
 			expectedBtcGateway, _ := addrEncodeDecoder.DecodeAddress(multichain.Address("FDdKRjbBeFtyu5c66cZghJsTTjDTT1aD3zsgTWMTpaif"))
-			expectedZecGateway, _ := addrEncodeDecoder.DecodeAddress(multichain.Address("9rCXCJDsnS53QtdXvYhYCAxb6yBE16KAQx5zHWfHe9QF"))
 
-			Expect(registry.Count).To(Equal(uint64(2)))
+			Expect(registry.Count).To(Equal(uint64(1)))
 			Expect(registry.Selectors[0]).To(Equal(btcSelectorHash))
-			Expect(registry.Selectors[1]).To(Equal(zecSelectorHash))
-			Expect(registry.Selectors[2]).To(Equal(zero))
+			Expect(registry.Selectors[1]).To(Equal(zero))
 			Expect(len(registry.Selectors)).To(Equal(32))
 			Expect(registry.Gateways[0][:]).To(Equal([]byte(expectedBtcGateway)))
-			Expect(registry.Gateways[1][:]).To(Equal([]byte(expectedZecGateway)))
-			Expect(registry.Gateways[2]).To(Equal(zero))
+			Expect(registry.Gateways[1]).To(Equal(zero))
 			Expect(len(registry.Gateways)).To(Equal(32))
 		})
 	})

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -142,3 +142,12 @@ services:
       - "0.0.0.0:28545:8545"
     entrypoint:
       - "./root/run.sh"
+
+  ##
+  ## Solana
+  ##
+  solana:
+    image: renbot/ren-solana:latest
+    ports:
+      - "0.0.0.0:8899:8899"
+      - "0.0.0.0:8900:8900"


### PR DESCRIPTION
- Uses `renbot/ren-solana` docker image for the CI
- Fixes tests based on the above change
- Adds `solana` service to the Multichain infra's `docker-compose` file