### PR TITLE
feat: trigger docker build on new tag | tag image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,18 @@
 name: Docker Build
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*.*.*'
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
+      - name: Set output
+        id: push-info
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -24,7 +30,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: renbot/multichain:latest
+          tags: renbot/multichain:${{ steps.push-info.outputs.tag }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN }}
           build-args: |


### PR DESCRIPTION
This PR triggers a docker build for multichain only when a new tag is created. It uses the tag version to also tag the docker image.