### PR TITLE
feat: add receipt logs for account tx

### DIFF
--- a/api/account/account.go
+++ b/api/account/account.go
@@ -52,7 +52,7 @@ type Tx interface {
 
 	// ReceiptLogs returns the data representating the EVM events logged as a
 	// result of this transaction.
-	ReceiptLogs() []pack.Bytes
+	ReceiptLogs() ([]address.Address, [][]pack.Bytes32, []pack.Bytes)
 }
 
 // The TxBuilder interface defines the functionality required to build

--- a/api/account/account.go
+++ b/api/account/account.go
@@ -49,6 +49,10 @@ type Tx interface {
 	// Serialize the transaction into bytes. This is the format in which the
 	// transaction will be submitted by the client.
 	Serialize() (pack.Bytes, error)
+
+	// ReceiptLogs returns the data representating the EVM events logged as a
+	// result of this transaction.
+	ReceiptLogs() []pack.Bytes
 }
 
 // The TxBuilder interface defines the functionality required to build

--- a/chain/cosmos/tx.go
+++ b/chain/cosmos/tx.go
@@ -340,9 +340,9 @@ func (tx StdTx) Serialize() (pack.Bytes, error) {
 
 // ReceiptLogs returns the data representating the EVM events logged as a
 // result of this transaction. In the case of Cosmos these are not applicable
-// hence we mark them as `nil`
-func (tx StdTx) ReceiptLogs() []pack.Bytes {
-	return nil
+// hence we mark them as `nil`.
+func (tx StdTx) ReceiptLogs() ([]address.Address, [][]pack.Bytes32, []pack.Bytes) {
+	return nil, nil, nil
 }
 
 // parseStdTx parse auth.StdTx to StdTx

--- a/chain/cosmos/tx.go
+++ b/chain/cosmos/tx.go
@@ -338,6 +338,13 @@ func (tx StdTx) Serialize() (pack.Bytes, error) {
 	return txBytes, nil
 }
 
+// ReceiptLogs returns the data representating the EVM events logged as a
+// result of this transaction. In the case of Cosmos these are not applicable
+// hence we mark them as `nil`
+func (tx StdTx) ReceiptLogs() []pack.Bytes {
+	return nil
+}
+
 // parseStdTx parse auth.StdTx to StdTx
 func parseStdTx(stdTx auth.StdTx) (StdTx, error) {
 	var msgs []MsgSend

--- a/chain/evm/client.go
+++ b/chain/evm/client.go
@@ -89,6 +89,7 @@ func (client *Client) Tx(ctx context.Context, txID pack.Bytes) (account.Tx, pack
 	confirmedTx := Tx{
 		tx,
 		types.LatestSignerForChainID(chainID),
+		receipt,
 	}
 
 	header, err := client.EthClient.HeaderByNumber(ctx, nil)

--- a/chain/evm/tx.go
+++ b/chain/evm/tx.go
@@ -118,10 +118,20 @@ func (tx Tx) Serialize() (pack.Bytes, error) {
 	return tx.EthTx.MarshalBinary()
 }
 
-func (tx Tx) ReceiptLogs() []pack.Bytes {
+// ReceiptLogs returns the data representating the EVM events logged as a
+// result of this transaction. Returned values include the address of the
+// contract that emitted the log, the topics and the log data.
+func (tx Tx) ReceiptLogs() ([]address.Address, [][]pack.Bytes32, []pack.Bytes) {
 	logs := make([]pack.Bytes, len(tx.Receipt.Logs))
+	topics := make([][]pack.Bytes32, len(tx.Receipt.Logs))
+	addresses := make([]address.Address, len(tx.Receipt.Logs))
 	for i := range tx.Receipt.Logs {
 		logs[i] = pack.NewBytes(tx.Receipt.Logs[i].Data)
+		topics[i] = []pack.Bytes32{}
+		for j := range tx.Receipt.Logs[i].Topics {
+			topics[i] = append(topics[i], pack.Bytes32(tx.Receipt.Logs[i].Topics[j]))
+		}
+		addresses[i] = address.Address(tx.Receipt.Logs[i].Address.Hex())
 	}
-	return logs
+	return addresses, topics, logs
 }

--- a/chain/evm/tx.go
+++ b/chain/evm/tx.go
@@ -39,15 +39,17 @@ func (txBuilder TxBuilder) BuildTx(ctx context.Context, from, to address.Address
 			gasPrice.Int(),
 			payload,
 		),
-		Signer: types.LatestSignerForChainID(txBuilder.ChainID),
+		Signer:  types.LatestSignerForChainID(txBuilder.ChainID),
+		Receipt: nil,
 	}, nil
 }
 
 // Tx represents a ethereum transaction, encapsulating a payload/data and its
 // Signer.
 type Tx struct {
-	EthTx  *types.Transaction
-	Signer types.Signer
+	EthTx   *types.Transaction
+	Signer  types.Signer
+	Receipt *types.Receipt
 }
 
 // Hash returns the hash that uniquely identifies the transaction.
@@ -114,4 +116,12 @@ func (tx *Tx) Sign(signatures []pack.Bytes65, pubkey pack.Bytes) error {
 // which the transaction will be submitted by the client.
 func (tx Tx) Serialize() (pack.Bytes, error) {
 	return tx.EthTx.MarshalBinary()
+}
+
+func (tx Tx) ReceiptLogs() []pack.Bytes {
+	logs := make([]pack.Bytes, len(tx.Receipt.Logs))
+	for i := range tx.Receipt.Logs {
+		logs[i] = pack.NewBytes(tx.Receipt.Logs[i].Data)
+	}
+	return logs
 }

--- a/chain/filecoin/account.go
+++ b/chain/filecoin/account.go
@@ -143,7 +143,7 @@ func (tx Tx) Serialize() (pack.Bytes, error) {
 
 // ReceiptLogs returns the data representating the EVM events logged as a result
 // of this transaction. In the case of Filecoin, these are not applicable hence
-// we mark them as `nil`
-func (tx Tx) ReceiptLogs() []pack.Bytes {
-	return nil
+// we mark them as `nil`.
+func (tx Tx) ReceiptLogs() ([]address.Address, [][]pack.Bytes32, []pack.Bytes) {
+	return nil, nil, nil
 }

--- a/chain/filecoin/account.go
+++ b/chain/filecoin/account.go
@@ -140,3 +140,10 @@ func (tx Tx) Serialize() (pack.Bytes, error) {
 	}
 	return buf.Bytes(), nil
 }
+
+// ReceiptLogs returns the data representating the EVM events logged as a result
+// of this transaction. In the case of Filecoin, these are not applicable hence
+// we mark them as `nil`
+func (tx Tx) ReceiptLogs() []pack.Bytes {
+	return nil
+}


### PR DESCRIPTION
Given the new contract changes in `gateway-sol` we would like to fetch burn logs from EVM tx receipt logs instead of querying storage.