### PR TITLE
fix: wait longer for daemon to start

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,129 +239,129 @@ jobs:
               -fil=true \
               -timeout 1500s
 
-#  test-zcash:
-#    runs-on: ubuntu-latest
-#    env:
-#      FILECOIN_FFI_COMMIT: 8b97bd8230b77bd32f4f27e4766a6d8a03b4e801
-#      SOLANA_FFI_COMMIT: 1428533377eb4ce00e81d04a53bad92f5339db00
-#    steps:
-#      - name: Set up Go 1.16
-#        uses: actions/setup-go@v1
-#        with:
-#          go-version: 1.16
-#        id: go
-#
-#      - name: Configure git for Private Modules
-#        env:
-#          TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-#        run: git config --global url."https://roynalnaruto:${TOKEN}@github.com".insteadOf "https://github.com"
-#
-#      - name: Check out code into the Go module directory
-#        uses: actions/checkout@v1
-#        with:
-#          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-#          submodules: recursive
-#
-#      - name: Caching modules
-#        uses: actions/cache@v1
-#        with:
-#          path: ~/go/pkg/mod
-#          key: ${{ runner.os }}-go-aw-${{ hashFiles('**/go.sum') }}
-#
-#      - name: Cache extern dependencies (FFI)
-#        id: cache-extern
-#        uses: actions/cache@v2
-#        env:
-#          cache-name: cache-externs
-#        with:
-#          path: .extern
-#          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.FILECOIN_FFI_COMMIT }}-${{ env.SOLANA_FFI_COMMIT }}
-#
-#      # Remove apt repos that are known to break from time to time
-#      # See https://github.com/actions/virtual-environments/issues/323
-#      - name: Install dependency packages
-#        run: |
-#          for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
-#          sudo apt-get update
-#          sudo apt-get install -y build-essential
-#          sudo apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev pkg-config libudev-dev hwloc libhwloc-dev
-#          curl https://sh.rustup.rs -sSf | sh -s -- -y
-#          source $HOME/.cargo/env
-#
-#      - name: Get dependencies
-#        run: |
-#            export PATH=$PATH:$(go env GOPATH)/bin
-#            source $HOME/.cargo/env
-#            go get -u github.com/onsi/ginkgo/ginkgo
-#            go get -u github.com/onsi/gomega/...
-#            go get -u golang.org/x/lint/golint
-#            go get -u github.com/loongy/covermerge
-#            go get -u github.com/mattn/goveralls
-#            go get -u github.com/xlab/c-for-go
-#
-#      - name: Install dependencies (Filecoin FFI)
-#        if: steps.cache-extern.outputs.cache-hit != 'true'
-#        run: |
-#          export PATH=$PATH:$(go env GOPATH)/bin
-#          source $HOME/.cargo/env
-#          cd $GITHUB_WORKSPACE
-#          mkdir .extern && cd .extern
-#          git clone https://github.com/filecoin-project/filecoin-ffi.git
-#          cd filecoin-ffi
-#          git checkout ${{ env.FILECOIN_FFI_COMMIT }}
-#          make
-#
-#      - name: Install dependencies (Solana FFI)
-#        if: steps.cache-extern.outputs.cache-hit != 'true'
-#        run: |
-#          export PATH=$PATH:$(go env GOPATH)/bin
-#          source $HOME/.cargo/env
-#          cd $GITHUB_WORKSPACE/.extern
-#          git clone https://github.com/renproject/solana-ffi.git
-#          cd solana-ffi
-#          git checkout ${{ env.SOLANA_FFI_COMMIT }}
-#          make clean
-#          make
-#
-#      - name: Run vetting
-#        run: |
-#            export PATH=$PATH:$(go env GOPATH)/bin
-#            source $HOME/.cargo/env
-#            go mod edit -replace=github.com/filecoin-project/filecoin-ffi=./.extern/filecoin-ffi
-#            go mod edit -replace=github.com/renproject/solana-ffi=./.extern/solana-ffi
-#            go vet ./...
-#
-#      - name: Run linting
-#        run: |
-#            cd $GITHUB_WORKSPACE
-#            export PATH=$PATH:$(go env GOPATH)/bin
-#            go get -u golang.org/x/lint/golint
-#            golint $(go list ./... | grep -v filecoin-ffi)
-#
-#      - name: Run multichain infrastructure
-#        run: |
-#            cd $GITHUB_WORKSPACE/infra
-#            source .env
-#            docker-compose up -d --build zcash
-#
-#      - name: Sleep until the nodes are up
-#        uses: jakejarvis/wait-action@master
-#        with:
-#          time: '1m'
-#
-#      - name: Check on docker containers
-#        run: docker ps -a
-#
-#      - name: Run tests and report test coverage
-#        env:
-#          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#            export PATH=$PATH:$(go env GOPATH)/bin
-#            source ./infra/.env
-#            cd $GITHUB_WORKSPACE
-#            go test \
-#              -zec=true \
-#              -timeout 1500s
+  test-zcash:
+    runs-on: ubuntu-latest
+    env:
+      FILECOIN_FFI_COMMIT: 8b97bd8230b77bd32f4f27e4766a6d8a03b4e801
+      SOLANA_FFI_COMMIT: 1428533377eb4ce00e81d04a53bad92f5339db00
+    steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+        id: go
+
+      - name: Configure git for Private Modules
+        env:
+          TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: git config --global url."https://roynalnaruto:${TOKEN}@github.com".insteadOf "https://github.com"
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          submodules: recursive
+
+      - name: Caching modules
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-aw-${{ hashFiles('**/go.sum') }}
+
+      - name: Cache extern dependencies (FFI)
+        id: cache-extern
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-externs
+        with:
+          path: .extern
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.FILECOIN_FFI_COMMIT }}-${{ env.SOLANA_FFI_COMMIT }}
+
+      # Remove apt repos that are known to break from time to time
+      # See https://github.com/actions/virtual-environments/issues/323
+      - name: Install dependency packages
+        run: |
+          for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+          sudo apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev pkg-config libudev-dev hwloc libhwloc-dev
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          source $HOME/.cargo/env
+
+      - name: Get dependencies
+        run: |
+            export PATH=$PATH:$(go env GOPATH)/bin
+            source $HOME/.cargo/env
+            go get -u github.com/onsi/ginkgo/ginkgo
+            go get -u github.com/onsi/gomega/...
+            go get -u golang.org/x/lint/golint
+            go get -u github.com/loongy/covermerge
+            go get -u github.com/mattn/goveralls
+            go get -u github.com/xlab/c-for-go
+
+      - name: Install dependencies (Filecoin FFI)
+        if: steps.cache-extern.outputs.cache-hit != 'true'
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          source $HOME/.cargo/env
+          cd $GITHUB_WORKSPACE
+          mkdir .extern && cd .extern
+          git clone https://github.com/filecoin-project/filecoin-ffi.git
+          cd filecoin-ffi
+          git checkout ${{ env.FILECOIN_FFI_COMMIT }}
+          make
+
+      - name: Install dependencies (Solana FFI)
+        if: steps.cache-extern.outputs.cache-hit != 'true'
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          source $HOME/.cargo/env
+          cd $GITHUB_WORKSPACE/.extern
+          git clone https://github.com/renproject/solana-ffi.git
+          cd solana-ffi
+          git checkout ${{ env.SOLANA_FFI_COMMIT }}
+          make clean
+          make
+
+      - name: Run vetting
+        run: |
+            export PATH=$PATH:$(go env GOPATH)/bin
+            source $HOME/.cargo/env
+            go mod edit -replace=github.com/filecoin-project/filecoin-ffi=./.extern/filecoin-ffi
+            go mod edit -replace=github.com/renproject/solana-ffi=./.extern/solana-ffi
+            go vet ./...
+
+      - name: Run linting
+        run: |
+            cd $GITHUB_WORKSPACE
+            export PATH=$PATH:$(go env GOPATH)/bin
+            go get -u golang.org/x/lint/golint
+            golint $(go list ./... | grep -v filecoin-ffi)
+
+      - name: Run multichain infrastructure
+        run: |
+            cd $GITHUB_WORKSPACE/infra
+            source .env
+            docker-compose up -d --build zcash
+
+      - name: Sleep until the nodes are up
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '1m'
+
+      - name: Check on docker containers
+        run: docker ps -a
+
+      - name: Run tests and report test coverage
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            export PATH=$PATH:$(go env GOPATH)/bin
+            source ./infra/.env
+            cd $GITHUB_WORKSPACE
+            go test \
+              -zec=true \
+              -timeout 1500s
 
   test-terra:
     runs-on: ubuntu-latest

--- a/infra/zcash/run.sh
+++ b/infra/zcash/run.sh
@@ -9,7 +9,7 @@ zcashd \
   -nuparams=2bb40e60:30  \
   -nuparams=f5b9230b:40  \
   -nuparams=e9ff75a6:50
-sleep 10
+sleep 20
 
 echo "ZCASH_ADDRESS=$ADDRESS"
 


### PR DESCRIPTION
After zcash v4.5.0, the daemon takes a bit longer to run. Inadequate sleep time means that the subsequent `importaddress` fails, which also then doesn't watch for that address. This in turn results in the `listunspent` RPC call returning an empty list.