### PR TITLE
Check filecoin tx method 

### DIFF
--- a/chain/filecoin/client.go
+++ b/chain/filecoin/client.go
@@ -11,6 +11,7 @@ import (
 	filclient "github.com/filecoin-project/lotus/api/client"
 	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/ipfs/go-cid"
 	"github.com/renproject/multichain/api/account"
 	"github.com/renproject/multichain/api/address"
@@ -136,6 +137,11 @@ func (client *Client) Tx(ctx context.Context, txID pack.Bytes) (account.Tx, pack
 	msg, err := client.node.ChainGetMessage(ctx, msgID)
 	if err != nil {
 		return nil, pack.NewU64(0), fmt.Errorf("getting txid %v from chain: %v", msgID, err)
+	}
+
+	// support `Send` method for now
+	if msg.Method != builtin.MethodSend {
+		return nil, pack.NewU64(0), fmt.Errorf("unsupport tx method, expect `%v`, got `%v`", builtin.MethodSend, msg.Method)
 	}
 
 	return &Tx{msg: *msg}, pack.NewU64(confs), nil


### PR DESCRIPTION
- Limit the tx method to be `Send` for filecoin deposits 