### PR TITLE
Support for non-Ethereum stablecoins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
-          go get -u github.com/xlab/c-for-go
+          go get -u github.com/xlab/c-for-go@cef5ec7
 
       - name: Install dependencies (Filecoin FFI)
         if: steps.cache-extern.outputs.cache-hit != 'true'
@@ -173,7 +173,7 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
-          go get -u github.com/xlab/c-for-go
+          go get -u github.com/xlab/c-for-go@cef5ec7
 
       - name: Install dependencies (Filecoin FFI)
         if: steps.cache-extern.outputs.cache-hit != 'true'
@@ -299,7 +299,7 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
-          go get -u github.com/xlab/c-for-go
+          go get -u github.com/xlab/c-for-go@cef5ec7
 
       - name: Install dependencies (Filecoin FFI)
         if: steps.cache-extern.outputs.cache-hit != 'true'
@@ -424,7 +424,7 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
-          go get -u github.com/xlab/c-for-go
+          go get -u github.com/xlab/c-for-go@cef5ec7
 
       - name: Install dependencies (Filecoin FFI)
         if: steps.cache-extern.outputs.cache-hit != 'true'
@@ -549,7 +549,7 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
-          go get -u github.com/xlab/c-for-go
+          go get -u github.com/xlab/c-for-go@cef5ec7
 
       - name: Install dependencies (Filecoin FFI)
         if: steps.cache-extern.outputs.cache-hit != 'true'
@@ -674,7 +674,7 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
-          go get -u github.com/xlab/c-for-go
+          go get -u github.com/xlab/c-for-go@cef5ec7
 
       - name: Install dependencies (Filecoin FFI)
         if: steps.cache-extern.outputs.cache-hit != 'true'
@@ -801,7 +801,7 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
-          go get -u github.com/xlab/c-for-go
+          go get -u github.com/xlab/c-for-go@cef5ec7
 
       - name: Install dependencies (Filecoin FFI)
         if: steps.cache-extern.outputs.cache-hit != 'true'
@@ -925,7 +925,7 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
-          go get -u github.com/xlab/c-for-go
+          go get -u github.com/xlab/c-for-go@cef5ec7
 
       - name: Install dependencies (Filecoin FFI)
         if: steps.cache-extern.outputs.cache-hit != 'true'
@@ -1049,7 +1049,7 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
-          go get -u github.com/xlab/c-for-go
+          go get -u github.com/xlab/c-for-go@cef5ec7
 
       - name: Install dependencies (Filecoin FFI)
         if: steps.cache-extern.outputs.cache-hit != 'true'
@@ -1173,7 +1173,7 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
-          go get -u github.com/xlab/c-for-go
+          go get -u github.com/xlab/c-for-go@cef5ec7
 
       - name: Install dependencies (Filecoin FFI)
         if: steps.cache-extern.outputs.cache-hit != 'true'
@@ -1297,7 +1297,7 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
-          go get -u github.com/xlab/c-for-go
+          go get -u github.com/xlab/c-for-go@cef5ec7
 
       - name: Install dependencies (Filecoin FFI)
         if: steps.cache-extern.outputs.cache-hit != 'true'

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/filecoin-project/go-jsonrpc v0.1.4-0.20210217175800-45ea43ac2bec
 	github.com/filecoin-project/go-state-types v0.1.1-0.20210506134452-99b279731c48
 	github.com/filecoin-project/lotus v1.10.0
+	github.com/filecoin-project/specs-actors v0.9.13
 	github.com/ipfs/go-cid v0.0.7
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/multiformats/go-varint v0.0.6

--- a/multichain.go
+++ b/multichain.go
@@ -110,19 +110,20 @@ const (
 	ETH    = Asset("ETH")    // Ether
 	FIL    = Asset("FIL")    // Filecoin
 	FTM    = Asset("FTM")    // Fantom
+	GETH   = Asset("GETH")   // Goerli Ether
 	GLMR   = Asset("GLMR")   // Glimmer
 	KAVA   = Asset("KAVA")   // Kava
 	LUNA   = Asset("LUNA")   // Luna
 	MATIC  = Asset("MATIC")  // Matic PoS (Polygon)
 	oETH   = Asset("oETH")   // Optimism Ether
 	SOL    = Asset("SOL")    // Solana
-	UST    = Asset("UST")    // TerraUSD
 	ZEC    = Asset("ZEC")    // Zcash
 
 	BADGER         = Asset("BADGER")         // Badger DAO
 	BUSD           = Asset("BUSD")           // Binance USD
 	CRV            = Asset("CRV")            // Curve
 	DAI            = Asset("DAI")            // Dai
+	DAI_Goerli     = Asset("DAI_Goerli")     // Dai (Goerli)
 	EURT           = Asset("EURT")           // Euro Tether
 	FTT            = Asset("FTT")            // FTX
 	ibBTC          = Asset("ibBTC")          // Interest Bearing Bitcoin
@@ -130,21 +131,18 @@ const (
 	LINK           = Asset("LINK")           // Chainlink
 	MIM            = Asset("MIM")            // Magic Internet Money
 	REN            = Asset("REN")            // Ren
+	REN_Goerli     = Asset("REN_Goerli")     // Ren (Goerli)
 	ROOK           = Asset("ROOK")           // KeeperDAO
 	SUSHI          = Asset("SUSHI")          // Sushiswap
 	UNI            = Asset("UNI")            // Uniswap
 	USDC           = Asset("USDC")           // Circle USD (Ethereum)
 	USDC_Avalanche = Asset("USDC_Avalanche") // Circle USD (Avalanche)
+	USDC_Goerli    = Asset("USDC_Goerli")    // Circle USD (Goerli)
 	USDC_Polygon   = Asset("USDC_Polygon")   // Circle USD (Polygon)
 	USDT           = Asset("USDT")           // Tether (Ethereum)
 	USDT_Avalanche = Asset("USDT_Avalanche") // Tether (Avalanche)
+	USDT_Goerli    = Asset("USDT_Goerli")    // Tether (Goerli)
 	USDT_Polygon   = Asset("USDT_Polygon")   // Tether (Polygon)
-
-	// These assets are defined separately because their purpose is to help us
-	// differentiate between different testnets for the same blockchain.
-
-	KETH = Asset("KETH") // Kovan ETH
-	GETH = Asset("GETH") // Goerli ETH
 
 	// These assets are defined separately because they are mock assets. These
 	// assets should only be used for testing.
@@ -215,6 +213,8 @@ func (asset Asset) OriginChain() Chain {
 		return Filecoin
 	case FTM:
 		return Fantom
+	case GETH:
+		return Goerli
 	case GLMR:
 		return Moonbeam
 	case KAVA:
@@ -227,8 +227,6 @@ func (asset Asset) OriginChain() Chain {
 		return Optimism
 	case SOL:
 		return Solana
-	case UST:
-		return Terra
 	case ZEC:
 		return Zcash
 
@@ -236,9 +234,7 @@ func (asset Asset) OriginChain() Chain {
 		SUSHI, UNI, USDC, USDT:
 		return Ethereum
 
-	case KETH:
-		return Kovan
-	case GETH:
+	case DAI_Goerli, REN_Goerli, USDC_Goerli, USDT_Goerli:
 		return Goerli
 
 	// These assets are handled separately because they are mock assets. These
@@ -261,16 +257,13 @@ func (asset Asset) ChainType() ChainType {
 	switch asset {
 	case BCH, BTC, DGB, DOGE, ZEC:
 		return ChainTypeUTXOBased
-	case ArbETH, AVAX, BNB, CAT, ETH, FIL, FTM, GLMR, KAVA, LUNA, MATIC, oETH,
-		SOL, UST:
+	case ArbETH, AVAX, BNB, CAT, ETH, FIL, FTM, GETH, GLMR, KAVA, LUNA, MATIC,
+		oETH, SOL:
 		return ChainTypeAccountBased
 
-	case BADGER, BUSD, CRV, DAI, EURT, FTT, ibBTC, KNC, LINK, MIM, REN, ROOK,
-		SUSHI, UNI, USDC, USDC_Avalanche, USDC_Polygon, USDT, USDT_Avalanche,
-		USDT_Polygon:
-		return ChainTypeAccountBased
-
-	case KETH, GETH:
+	case BADGER, BUSD, CRV, DAI, DAI_Goerli, EURT, FTT, ibBTC, KNC, LINK, MIM,
+		REN, REN_Goerli, ROOK, SUSHI, UNI, USDC, USDC_Avalanche, USDC_Goerli,
+		USDC_Polygon, USDT, USDT_Avalanche, USDT_Goerli, USDT_Polygon:
 		return ChainTypeAccountBased
 
 	// These assets are handled separately because they are mock assets. These
@@ -289,16 +282,13 @@ func (asset Asset) ChainType() ChainType {
 // Type returns the asset-type (Native or Token) for the given asset.
 func (asset Asset) Type() AssetType {
 	switch asset {
-	case ArbETH, AVAX, BNB, CAT, ETH, FTM, GLMR, KAVA, MATIC, oETH, SOL, UST:
+	case ArbETH, AVAX, BNB, CAT, ETH, FTM, GETH, GLMR, KAVA, MATIC, oETH, SOL:
 		return AssetTypeNative
 
-	case BADGER, BUSD, CRV, DAI, EURT, FTT, ibBTC, KNC, LINK, MIM, REN, ROOK,
-		SUSHI, UNI, USDC, USDC_Avalanche, USDC_Polygon, USDT, USDT_Avalanche,
-		USDT_Polygon:
+	case BADGER, BUSD, CRV, DAI, DAI_Goerli, EURT, FTT, ibBTC, KNC, LINK, MIM,
+		REN, REN_Goerli, ROOK, SUSHI, UNI, USDC, USDC_Avalanche, USDC_Goerli,
+		USDC_Polygon, USDT, USDT_Avalanche, USDT_Goerli, USDT_Polygon:
 		return AssetTypeToken
-
-	case KETH, GETH:
-		return AssetTypeNative
 
 	// These assets are handled separately because they are mock assets. These
 	// assets should only be used for testing.
@@ -426,6 +416,8 @@ func (chain Chain) IsUTXOBased() bool {
 // root asset of Bitcoin chain is BTC.
 func (chain Chain) NativeAsset() Asset {
 	switch chain {
+	case Arbitrum:
+		return ArbETH
 	case Avalanche:
 		return AVAX
 	case BinanceSmartChain:
@@ -446,6 +438,8 @@ func (chain Chain) NativeAsset() Asset {
 		return FTM
 	case Filecoin:
 		return FIL
+	case Goerli:
+		return GETH
 	case Kava:
 		return KAVA
 	case Moonbeam:
@@ -460,13 +454,6 @@ func (chain Chain) NativeAsset() Asset {
 		return LUNA
 	case Zcash:
 		return ZEC
-	case Arbitrum:
-		return ArbETH
-
-	case Kovan:
-		return KETH
-	case Goerli:
-		return GETH
 
 	// These chains are handled separately because they are mock chains. These
 	// chains should only be used for testing.

--- a/multichain.go
+++ b/multichain.go
@@ -119,22 +119,26 @@ const (
 	UST    = Asset("UST")    // TerraUSD
 	ZEC    = Asset("ZEC")    // Zcash
 
-	BADGER = Asset("BADGER") // Badger DAO
-	BUSD   = Asset("BUSD")   // Binance USD
-	CRV    = Asset("CRV")    // Curve
-	DAI    = Asset("DAI")    // Dai
-	EURT   = Asset("EURT")   // Euro Tether
-	FTT    = Asset("FTT")    // FTX
-	ibBTC  = Asset("ibBTC")  // Interest Bearing Bitcoin
-	KNC    = Asset("KNC")    // Kyber Network
-	LINK   = Asset("LINK")   // Chainlink
-	MIM    = Asset("MIM")    // Magic Internet Money
-	REN    = Asset("REN")    // Ren
-	ROOK   = Asset("ROOK")   // KeeperDAO
-	SUSHI  = Asset("SUSHI")  // Sushiswap
-	UNI    = Asset("UNI")    // Uniswap
-	USDC   = Asset("USDC")   // Circle USD
-	USDT   = Asset("USDT")   // Tether
+	BADGER         = Asset("BADGER")         // Badger DAO
+	BUSD           = Asset("BUSD")           // Binance USD
+	CRV            = Asset("CRV")            // Curve
+	DAI            = Asset("DAI")            // Dai
+	EURT           = Asset("EURT")           // Euro Tether
+	FTT            = Asset("FTT")            // FTX
+	ibBTC          = Asset("ibBTC")          // Interest Bearing Bitcoin
+	KNC            = Asset("KNC")            // Kyber Network
+	LINK           = Asset("LINK")           // Chainlink
+	MIM            = Asset("MIM")            // Magic Internet Money
+	REN            = Asset("REN")            // Ren
+	ROOK           = Asset("ROOK")           // KeeperDAO
+	SUSHI          = Asset("SUSHI")          // Sushiswap
+	UNI            = Asset("UNI")            // Uniswap
+	USDC           = Asset("USDC")           // Circle USD (Ethereum)
+	USDC_Avalanche = Asset("USDC_Avalanche") // Circle USD (Avalanche)
+	USDC_Polygon   = Asset("USDC_Polygon")   // Circle USD (Polygon)
+	USDT           = Asset("USDT")           // Tether (Ethereum)
+	USDT_Avalanche = Asset("USDT_Avalanche") // Tether (Avalanche)
+	USDT_Polygon   = Asset("USDT_Polygon")   // Tether (Polygon)
 
 	// These assets are defined separately because their purpose is to help us
 	// differentiate between different testnets for the same blockchain.
@@ -191,7 +195,7 @@ func (asset Asset) OriginChain() Chain {
 	switch asset {
 	case ArbETH:
 		return Arbitrum
-	case AVAX:
+	case AVAX, USDC_Avalanche, USDT_Avalanche:
 		return Avalanche
 	case BCH:
 		return BitcoinCash
@@ -217,7 +221,7 @@ func (asset Asset) OriginChain() Chain {
 		return Kava
 	case LUNA:
 		return Terra
-	case MATIC:
+	case MATIC, USDC_Polygon, USDT_Polygon:
 		return Polygon
 	case oETH:
 		return Optimism
@@ -262,7 +266,8 @@ func (asset Asset) ChainType() ChainType {
 		return ChainTypeAccountBased
 
 	case BADGER, BUSD, CRV, DAI, EURT, FTT, ibBTC, KNC, LINK, MIM, REN, ROOK,
-		SUSHI, UNI, USDC, USDT:
+		SUSHI, UNI, USDC, USDC_Avalanche, USDC_Polygon, USDT, USDT_Avalanche,
+		USDT_Polygon:
 		return ChainTypeAccountBased
 
 	case KETH, GETH:
@@ -288,7 +293,8 @@ func (asset Asset) Type() AssetType {
 		return AssetTypeNative
 
 	case BADGER, BUSD, CRV, DAI, EURT, FTT, ibBTC, KNC, LINK, MIM, REN, ROOK,
-		SUSHI, UNI, USDC, USDT:
+		SUSHI, UNI, USDC, USDC_Avalanche, USDC_Polygon, USDT, USDT_Avalanche,
+		USDT_Polygon:
 		return AssetTypeToken
 
 	case KETH, GETH:

--- a/multichain.go
+++ b/multichain.go
@@ -119,30 +119,33 @@ const (
 	SOL    = Asset("SOL")    // Solana
 	ZEC    = Asset("ZEC")    // Zcash
 
-	BADGER         = Asset("BADGER")         // Badger DAO
-	BUSD           = Asset("BUSD")           // Binance USD
-	CRV            = Asset("CRV")            // Curve
-	DAI            = Asset("DAI")            // Dai
-	DAI_Goerli     = Asset("DAI_Goerli")     // Dai (Goerli)
-	EURT           = Asset("EURT")           // Euro Tether
-	FTT            = Asset("FTT")            // FTX
-	ibBTC          = Asset("ibBTC")          // Interest Bearing Bitcoin
-	KNC            = Asset("KNC")            // Kyber Network
-	LINK           = Asset("LINK")           // Chainlink
-	MIM            = Asset("MIM")            // Magic Internet Money
-	REN            = Asset("REN")            // Ren
-	REN_Goerli     = Asset("REN_Goerli")     // Ren (Goerli)
-	ROOK           = Asset("ROOK")           // KeeperDAO
-	SUSHI          = Asset("SUSHI")          // Sushiswap
-	UNI            = Asset("UNI")            // Uniswap
-	USDC           = Asset("USDC")           // Circle USD (Ethereum)
 	USDC_Avalanche = Asset("USDC_Avalanche") // Circle USD (Avalanche)
-	USDC_Goerli    = Asset("USDC_Goerli")    // Circle USD (Goerli)
-	USDC_Polygon   = Asset("USDC_Polygon")   // Circle USD (Polygon)
-	USDT           = Asset("USDT")           // Tether (Ethereum)
 	USDT_Avalanche = Asset("USDT_Avalanche") // Tether (Avalanche)
-	USDT_Goerli    = Asset("USDT_Goerli")    // Tether (Goerli)
-	USDT_Polygon   = Asset("USDT_Polygon")   // Tether (Polygon)
+
+	BADGER = Asset("BADGER") // Badger DAO
+	BUSD   = Asset("BUSD")   // Binance USD
+	CRV    = Asset("CRV")    // Curve
+	DAI    = Asset("DAI")    // Dai
+	EURT   = Asset("EURT")   // Euro Tether
+	FTT    = Asset("FTT")    // FTX
+	ibBTC  = Asset("ibBTC")  // Interest Bearing Bitcoin
+	KNC    = Asset("KNC")    // Kyber Network
+	LINK   = Asset("LINK")   // Chainlink
+	MIM    = Asset("MIM")    // Magic Internet Money
+	REN    = Asset("REN")    // Ren
+	ROOK   = Asset("ROOK")   // KeeperDAO
+	SUSHI  = Asset("SUSHI")  // Sushiswap
+	UNI    = Asset("UNI")    // Uniswap
+	USDC   = Asset("USDC")   // Circle USD (Ethereum)
+	USDT   = Asset("USDT")   // Tether (Ethereum)
+
+	DAI_Goerli  = Asset("DAI_Goerli")  // Dai (Goerli)
+	REN_Goerli  = Asset("REN_Goerli")  // Ren (Goerli)
+	USDC_Goerli = Asset("USDC_Goerli") // Circle USD (Goerli)
+	USDT_Goerli = Asset("USDT_Goerli") // Tether (Goerli)
+
+	USDC_Polygon = Asset("USDC_Polygon") // Circle USD (Polygon)
+	USDT_Polygon = Asset("USDT_Polygon") // Tether (Polygon)
 
 	// These assets are defined separately because they are mock assets. These
 	// assets should only be used for testing.
@@ -193,7 +196,7 @@ func (asset Asset) OriginChain() Chain {
 	switch asset {
 	case ArbETH:
 		return Arbitrum
-	case AVAX, USDC_Avalanche, USDT_Avalanche:
+	case AVAX:
 		return Avalanche
 	case BCH:
 		return BitcoinCash
@@ -221,7 +224,7 @@ func (asset Asset) OriginChain() Chain {
 		return Kava
 	case LUNA:
 		return Terra
-	case MATIC, USDC_Polygon, USDT_Polygon:
+	case MATIC:
 		return Polygon
 	case oETH:
 		return Optimism
@@ -230,12 +233,15 @@ func (asset Asset) OriginChain() Chain {
 	case ZEC:
 		return Zcash
 
+	case USDC_Avalanche, USDT_Avalanche:
+		return Avalanche
 	case BADGER, BUSD, CRV, DAI, EURT, FTT, ibBTC, KNC, LINK, MIM, REN, ROOK,
 		SUSHI, UNI, USDC, USDT:
 		return Ethereum
-
 	case DAI_Goerli, REN_Goerli, USDC_Goerli, USDT_Goerli:
 		return Goerli
+	case USDC_Polygon, USDT_Polygon:
+		return Polygon
 
 	// These assets are handled separately because they are mock assets. These
 	// assets should only be used for testing.
@@ -261,9 +267,14 @@ func (asset Asset) ChainType() ChainType {
 		oETH, SOL:
 		return ChainTypeAccountBased
 
-	case BADGER, BUSD, CRV, DAI, DAI_Goerli, EURT, FTT, ibBTC, KNC, LINK, MIM,
-		REN, REN_Goerli, ROOK, SUSHI, UNI, USDC, USDC_Avalanche, USDC_Goerli,
-		USDC_Polygon, USDT, USDT_Avalanche, USDT_Goerli, USDT_Polygon:
+	case USDC_Avalanche, USDT_Avalanche:
+		return ChainTypeAccountBased
+	case BADGER, BUSD, CRV, DAI, EURT, FTT, ibBTC, KNC, LINK, MIM,
+		REN, ROOK, SUSHI, UNI, USDC, USDT:
+		return ChainTypeAccountBased
+	case DAI_Goerli, REN_Goerli, USDC_Goerli, USDT_Goerli:
+		return ChainTypeAccountBased
+	case USDC_Polygon, USDT_Polygon:
 		return ChainTypeAccountBased
 
 	// These assets are handled separately because they are mock assets. These
@@ -285,9 +296,14 @@ func (asset Asset) Type() AssetType {
 	case ArbETH, AVAX, BNB, CAT, ETH, FTM, GETH, GLMR, KAVA, MATIC, oETH, SOL:
 		return AssetTypeNative
 
-	case BADGER, BUSD, CRV, DAI, DAI_Goerli, EURT, FTT, ibBTC, KNC, LINK, MIM,
-		REN, REN_Goerli, ROOK, SUSHI, UNI, USDC, USDC_Avalanche, USDC_Goerli,
-		USDC_Polygon, USDT, USDT_Avalanche, USDT_Goerli, USDT_Polygon:
+	case USDC_Avalanche, USDT_Avalanche:
+		return AssetTypeToken
+	case BADGER, BUSD, CRV, DAI, EURT, FTT, ibBTC, KNC, LINK, MIM,
+		REN, ROOK, SUSHI, UNI, USDC, USDT:
+		return AssetTypeToken
+	case DAI_Goerli, REN_Goerli, USDC_Goerli, USDT_Goerli:
+		return AssetTypeToken
+	case USDC_Polygon, USDT_Polygon:
 		return AssetTypeToken
 
 	// These assets are handled separately because they are mock assets. These

--- a/multichain_test.go
+++ b/multichain_test.go
@@ -145,10 +145,6 @@ var _ = Describe("Multichain", func() {
 					multichain.LUNA,
 				},
 				{
-					multichain.Kovan,
-					multichain.KETH,
-				},
-				{
 					multichain.Goerli,
 					multichain.GETH,
 				},


### PR DESCRIPTION
Add support for non-Ethereum stablecoins such as USDC/USDT on Polygon/Avalanche. This PR also defines some new types for token assets on Goerli.